### PR TITLE
Use a VFS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -32,6 +32,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "camino"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
+
+[[package]]
 name = "clap"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,12 +101,6 @@ dependencies = [
  "quote",
  "syn",
 ]
-
-[[package]]
-name = "dunce"
-version = "1.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
 name = "fnv"
@@ -200,7 +200,7 @@ checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 name = "mqpkg"
 version = "0.1.0"
 dependencies = [
- "dunce",
+ "camino",
  "serde",
  "serde_with",
  "serde_yaml",
@@ -214,6 +214,7 @@ name = "mqpkg-cli"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "camino",
  "clap",
  "mqpkg",
  "vfs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -206,6 +206,7 @@ dependencies = [
  "serde_yaml",
  "thiserror",
  "url",
+ "vfs",
 ]
 
 [[package]]
@@ -215,6 +216,7 @@ dependencies = [
  "anyhow",
  "clap",
  "mqpkg",
+ "vfs",
 ]
 
 [[package]]
@@ -447,6 +449,15 @@ name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
+
+[[package]]
+name = "vfs"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67fe15bc81afdceeaedd710d237f9043e895fd619db42cb503d9bfbb27a9f3a1"
+dependencies = [
+ "thiserror",
+]
 
 [[package]]
 name = "winapi"

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -10,5 +10,6 @@ path = "src/main.rs"
 [dependencies]
 mqpkg = { path = "../mqpkg" }
 anyhow = "1.0"
+camino = "1.0.7"
 clap = { version = "3.1.0", features = ["derive"] }
 vfs = "0.5.2"

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -11,3 +11,4 @@ path = "src/main.rs"
 mqpkg = { path = "../mqpkg" }
 anyhow = "1.0"
 clap = { version = "3.1.0", features = ["derive"] }
+vfs = "0.5.2"

--- a/mqpkg-cli/src/main.rs
+++ b/mqpkg-cli/src/main.rs
@@ -32,15 +32,14 @@ fn main() -> Result<()> {
     let cli = Cli::parse();
     let root = match cli.target {
         Some(target) => target,
-        None => {
-            let cur = Utf8PathBuf::try_from(std::env::current_dir()?)?;
-            find_config_dir(cur).with_context(|| {
+        None => find_config_dir(Utf8PathBuf::try_from(std::env::current_dir()?)?).with_context(
+            || {
                 format!(
                     "Unable to find '{}' in current directory or parents",
                     CONFIG_FILENAME
                 )
-            })?
-        }
+            },
+        )?,
     };
     let fs: VfsPath = PhysicalFS::new(PathBuf::from(root)).into();
     let _config =

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -10,3 +10,4 @@ serde_with = "1.12.0"
 serde_yaml = "0.8"
 thiserror = "1.0"
 url = { version = "2", features = ["serde"] }
+vfs = "0.5.2"

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-dunce = "1.0"
+camino = "1.0.7"
 serde = { version = "1.0", features = ["derive"] }
 serde_with = "1.12.0"
 serde_yaml = "0.8"

--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -2,9 +2,9 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use std::path::PathBuf;
 use std::str::FromStr;
 
+use camino::Utf8PathBuf;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use thiserror::Error;
@@ -69,9 +69,9 @@ impl Config {
     }
 }
 
-pub fn find_config_dir<P>(path: P) -> Result<PathBuf, ConfigError>
+pub fn find_config_dir<P>(path: P) -> Result<Utf8PathBuf, ConfigError>
 where
-    P: Into<PathBuf>,
+    P: Into<Utf8PathBuf>,
 {
     let mut path = path.into();
     loop {

--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -2,17 +2,17 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use std::fs::File;
-use std::path::{Path, PathBuf};
+use std::path::PathBuf;
 use std::str::FromStr;
 
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use url::Url;
+use vfs::VfsPath;
 
 use super::Error;
 
-const CONFIG_FILENAME: &str = "mqpkg.yml";
+pub const CONFIG_FILENAME: &str = "mqpkg.yml";
 
 #[derive(Deserialize, Debug)]
 struct Repository {
@@ -33,52 +33,41 @@ impl FromStr for Repository {
 #[serde_with::serde_as]
 #[derive(Deserialize, Debug)]
 pub struct Config {
-    #[serde(skip)]
-    target: PathBuf,
-
     #[serde(rename = "repositories")]
     #[serde_as(as = "Vec<PickFirst<(_, DisplayFromStr)>>")]
     _repositories: Vec<Repository>,
 }
 
 impl Config {
-    pub fn target(&self) -> &Path {
-        self.target.as_path()
+    pub fn load(root: VfsPath) -> Result<Config, Error> {
+        let configfile = root
+            .join(CONFIG_FILENAME)
+            .map_err(|source| Error::NoConfig { source })?
+            .open_file()
+            .map_err(|source| Error::NoConfig { source })?;
+        let config: Config = serde_yaml::from_reader(configfile)
+            .map_err(|source| Error::InvalidConfig { source })?;
+
+        Ok(config)
     }
 }
 
-impl Config {
-    pub fn load<P>(path: P) -> Result<Config, Error>
-    where
-        P: AsRef<Path>,
-    {
-        let target = dunce::canonicalize(path)?;
-        let configfile = File::open(target.join(CONFIG_FILENAME))
-            .map_err(|source| Error::NoConfig { source })?;
-        let config: Config = serde_yaml::from_reader(configfile)?;
+pub fn find_config_dir<P>(path: P) -> Result<PathBuf, Error>
+where
+    P: Into<PathBuf>,
+{
+    let mut path = path.into();
+    loop {
+        path.push(CONFIG_FILENAME);
+        if path.is_file() {
+            assert!(path.pop());
+            break Ok(path);
+        }
 
-        Ok(Config { target, ..config })
-    }
-
-    pub fn find<P>(path: P) -> Result<Config, Error>
-    where
-        P: Into<PathBuf>,
-    {
-        let mut path = path.into();
-        let target = loop {
-            path.push(CONFIG_FILENAME);
-            if path.is_file() {
-                assert!(path.pop());
-                break path;
-            }
-
-            // Remove the filename, and the parent, and
-            // if that's not successful, it's an error.
-            if !(path.pop() && path.pop()) {
-                return Err(Error::NoTargetDirectoryFound);
-            }
-        };
-
-        Config::load(target)
+        // Remove the filename, and the parent, and
+        // if that's not successful, it's an error.
+        if !(path.pop() && path.pop()) {
+            return Err(Error::NoTargetDirectoryFound);
+        }
     }
 }

--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -57,12 +57,12 @@ pub struct Config {
 
 impl Config {
     pub fn load(root: &VfsPath) -> Result<Config, ConfigError> {
-        let configfile = root
+        let file = root
             .join(CONFIG_FILENAME)
             .map_err(|source| ConfigError::NoConfig { source })?
             .open_file()
             .map_err(|source| ConfigError::NoConfig { source })?;
-        let config: Config = serde_yaml::from_reader(configfile)
+        let config: Config = serde_yaml::from_reader(file)
             .map_err(|source| ConfigError::InvalidConfig { source })?;
 
         Ok(config)

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -2,26 +2,4 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
-use thiserror::Error as BaseError;
-
-pub use self::config::{find_config_dir, Config, CONFIG_FILENAME};
-
-mod config;
-
-#[derive(BaseError, Debug)]
-pub enum Error {
-    #[error("no configuration file")]
-    NoConfig { source: vfs::VfsError },
-
-    #[error("invalid configuration")]
-    InvalidConfig { source: serde_yaml::Error },
-
-    #[error("invalid url")]
-    InvalidURL { source: url::ParseError },
-
-    #[error("unable to traverse directory")]
-    DirectoryTraversalError { source: vfs::VfsError },
-
-    #[error("unable to locate a valid directory")]
-    NoTargetDirectoryFound,
-}
+pub mod config;

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -4,29 +4,23 @@
 
 use thiserror::Error as BaseError;
 
-pub use self::config::Config;
+pub use self::config::{find_config_dir, Config, CONFIG_FILENAME};
 
 mod config;
 
 #[derive(BaseError, Debug)]
 pub enum Error {
     #[error("no configuration file")]
-    NoConfig {
-        #[from]
-        source: std::io::Error,
-    },
+    NoConfig { source: vfs::VfsError },
 
     #[error("invalid configuration")]
-    InvalidConfig {
-        #[from]
-        source: serde_yaml::Error,
-    },
+    InvalidConfig { source: serde_yaml::Error },
 
     #[error("invalid url")]
-    InvalidURL {
-        #[from]
-        source: url::ParseError,
-    },
+    InvalidURL { source: url::ParseError },
+
+    #[error("unable to traverse directory")]
+    DirectoryTraversalError { source: vfs::VfsError },
 
     #[error("unable to locate a valid directory")]
     NoTargetDirectoryFound,


### PR DESCRIPTION
Instead of hitting the filesystem directly, use a VFS unless a function *has* to work with the filesystem directly.

This also gets rid of ``Config::find()``, which would find a config directory and then load it, and replaces it with a seperate function that just finds the config directory and leaves it up to the caller to then call ``Config::load()``. This was done because we want our VFS to be rooted in our target directory, which means we can't easily iterate upwards without just making a VFS rooted at the root of the drive.

This ends up making both paths far more consistent, which will reduce special cases as much as possible. 

This also moves ``mqpkg::Error`` to ``mqpkg::config::ConfigError``, and makes the ``mqpkg::config`` module itself public.

This also drops the ``Config.target`` member, it was making deserialization more difficult to have it there anyways, and with the VFS now the ``Config::load()`` method doesn't actually know where our target directory is, it sees the target directory as the "root" of the filesystem that it's working with.

Finally, this also switches things around to use Camino as much as possible to ensure that all of our paths are valid utf8.