### PR TITLE
Implement a resolver with basic repository support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 /demo
+/TODO

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -571,6 +571,7 @@ name = "mqpkg"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "indexmap",
  "md5",
  "named-lock",
  "pubgrub",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,10 +3,29 @@
 version = 3
 
 [[package]]
+name = "adler"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
+
+[[package]]
 name = "anyhow"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a99269dff3bc004caa411f38845c20303f1e393ca2bd6581576fa3a7f59577d"
+
+[[package]]
+name = "async-compression"
+version = "0.3.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2bf394cfbbe876f0ac67b13b6ca819f9c9f2fb9ec67223cceb1555fbab1c31a"
+dependencies = [
+ "flate2",
+ "futures-core",
+ "memchr",
+ "pin-project-lite",
+ "tokio",
+]
 
 [[package]]
 name = "atty"
@@ -26,10 +45,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
 
 [[package]]
+name = "base64"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "904dfeac50f3cdaba28fc6f57fdcddb75f49ed61346676a78c4ffe55877802fd"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
+
+[[package]]
+name = "bumpalo"
+version = "3.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4a45a46ab1f2412e53d3a0ade76ffad2025804294569aae387231a0cd6e0899"
+
+[[package]]
+name = "bytes"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4872d67bab6358e59559027aa3b9157c53d9358c51423c17554809a8858e0f8"
 
 [[package]]
 name = "camino"
@@ -38,10 +75,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6f3132262930b0522068049f5870a856ab8affc80c70d08b6ecb785771a6fc23"
 
 [[package]]
+name = "cc"
+version = "1.0.73"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4785bdd1c96b2a846b2bd7cc02e86b6b3dbf14e7e53446c4f54c92a361040822"
+
+[[package]]
+name = "cfg-if"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "clap"
@@ -80,6 +129,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ddfc5b9aa5d4507acaf872de71051dfd0e309860e88966e1051e462a077aac4f"
 dependencies = [
  "bitflags",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "194a7a9e6de53fa55116934067c844d9d749312f75c6f6d0980e8c252f8c2146"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5827cebf4670468b8772dd191856768aedcb1b0278a04f989f7766351917b9dc"
+
+[[package]]
+name = "crc32fast"
+version = "1.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
+dependencies = [
+ "cfg-if 1.0.0",
 ]
 
 [[package]]
@@ -124,10 +198,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
 
 [[package]]
+name = "encoding_rs"
+version = "0.8.30"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7896dc8abb250ffdda33912550faa54c88ec8b998dec0b2c55ab224921ce11df"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "fastrand"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3fcf0cee53519c866c09b5de1f6c56ff9d647101f81c1964fa632e148896cdf"
+dependencies = [
+ "instant",
+]
+
+[[package]]
+name = "flate2"
+version = "1.0.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6988e897c1c9c485f43b47a529cef42fde0547f9d8d41a7062518f1d8fc53f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "crc32fast",
+ "libc",
+ "miniz_oxide",
+]
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foreign-types"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6f339eb8adc052cd2ca78910fda869aefa38d22d5cb648e6485e4d3fc06f3b1"
+dependencies = [
+ "foreign-types-shared",
+]
+
+[[package]]
+name = "foreign-types-shared"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "00b0228411908ca8685dba7fc2cdd70ec9990a6e753e89b6ac91a84c40fbaf4b"
 
 [[package]]
 name = "form_urlencoded"
@@ -137,6 +256,73 @@ checksum = "5fc25a87fa4fd2094bffb06925852034d90a17f0d1e05197d4956d3555752191"
 dependencies = [
  "matches",
  "percent-encoding",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3083ce4b914124575708913bca19bfe887522d6e2e6d0952943f5eac4a74010"
+dependencies = [
+ "futures-core",
+]
+
+[[package]]
+name = "futures-core"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c09fd04b7e4073ac7156a9539b57a484a8ea920f79c7c675d05d289ab6110d3"
+
+[[package]]
+name = "futures-io"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc4045962a5a5e935ee2fdedaa4e08284547402885ab326734432bed5d12966b"
+
+[[package]]
+name = "futures-sink"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "21163e139fa306126e6eedaf49ecdb4588f939600f0b1e770f4205ee4b7fa868"
+
+[[package]]
+name = "futures-task"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c66a976bf5909d801bbef33416c41372779507e7a6b3a5e25e4749c58f776a"
+
+[[package]]
+name = "futures-util"
+version = "0.3.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8b7abd5d659d9b90c8cba917f6ec750a74e2dc23902ef9cd4cc8c8b22e6036a"
+dependencies = [
+ "futures-core",
+ "futures-io",
+ "futures-task",
+ "memchr",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+]
+
+[[package]]
+name = "h2"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9f1f717ddc7b2ba36df7e871fd88db79326551d3d6f1fc406fbfd28b582ff8e"
+dependencies = [
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "futures-util",
+ "http",
+ "indexmap",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
 ]
 
 [[package]]
@@ -158,6 +344,77 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "http"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "31f4c6746584866f0feabcc69893c5b51beef3831656a968ed7ae254cdc4fd03"
+dependencies = [
+ "bytes",
+ "fnv",
+ "itoa",
+]
+
+[[package]]
+name = "http-body"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ff4f84919677303da5f147645dbea6b1881f368d03ac84e1dc09031ebd7b2c6"
+dependencies = [
+ "bytes",
+ "http",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "httparse"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9100414882e15fb7feccb4897e5f0ff0ff1ca7d1a86a23208ada4d7a18e6c6c4"
+
+[[package]]
+name = "httpdate"
+version = "1.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "hyper"
+version = "0.14.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "043f0e083e9901b6cc658a77d1eb86f4fc650bbb977a4337dd63192826aa85dd"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "httparse",
+ "httpdate",
+ "itoa",
+ "pin-project-lite",
+ "socket2",
+ "tokio",
+ "tower-service",
+ "tracing",
+ "want",
+]
+
+[[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
 ]
 
 [[package]]
@@ -188,6 +445,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "instant"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a5bbe824c507c5da5956355e86a746d82e0e1464f65d862cc5e71da70e94b2c"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
+name = "ipnet"
+version = "2.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68f2d64f2edebec4ce84ad108148e67e1064789bee435edc5b60ad398714a3a9"
+
+[[package]]
+name = "itoa"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aab8fc367588b89dcee83ab0fd66b72b50b72fa1904d7095045ace2b0c81c35"
+
+[[package]]
+name = "js-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a38fc24e30fd564ce974c02bf1d337caddff65be6cc4735a1f7eab22a7440f04"
+dependencies = [
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +502,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "log"
+version = "0.4.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51b9bbe6c47d51fc3e1a9b945965946b4c44142ab8792c50835a980d362c2710"
+dependencies = [
+ "cfg-if 1.0.0",
+]
+
+[[package]]
 name = "matches"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -233,14 +529,55 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "308cc39be01b73d0d18f82a0e7b2a3df85245f84af96fdddc5d202d27e47b86a"
 
 [[package]]
+name = "mime"
+version = "0.3.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a60c7ce501c71e03a9c9c0d35b861413ae925bd979cc7a4e30d060069aaac8d"
+
+[[package]]
+name = "miniz_oxide"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a92518e98c078586bc6c934028adcca4c92a53d6a958196de835170a01d84e4b"
+dependencies = [
+ "adler",
+ "autocfg",
+]
+
+[[package]]
+name = "mio"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba272f85fa0b41fc91872be579b3bbe0f56b792aa361a380eb669469f68dafb2"
+dependencies = [
+ "libc",
+ "log",
+ "miow",
+ "ntapi",
+ "winapi",
+]
+
+[[package]]
+name = "miow"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9f1c5b025cda876f66ef43a113f91ebc9f4ccef34843000e0adf6ebbab84e21"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
 name = "mqpkg"
 version = "0.1.0"
 dependencies = [
  "camino",
  "md5",
  "named-lock",
+ "pubgrub",
+ "reqwest",
  "semver",
  "serde",
+ "serde_json",
  "serde_with",
  "serde_yaml",
  "thiserror",
@@ -275,10 +612,80 @@ dependencies = [
 ]
 
 [[package]]
+name = "native-tls"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48ba9f7719b5a0f42f338907614285fb5fd70e53858141f69898a1fb7203b24d"
+dependencies = [
+ "lazy_static",
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
+]
+
+[[package]]
+name = "ntapi"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c28774a7fd2fbb4f0babd8237ce554b73af68021b5f695a3cebd6c59bac0980f"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
+dependencies = [
+ "hermit-abi",
+ "libc",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
+
+[[package]]
+name = "openssl"
+version = "0.10.38"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7ae222234c30df141154f159066c5093ff73b63204dcda7121eb082fc56a95"
+dependencies = [
+ "bitflags",
+ "cfg-if 1.0.0",
+ "foreign-types",
+ "libc",
+ "once_cell",
+ "openssl-sys",
+]
+
+[[package]]
+name = "openssl-probe"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
+
+[[package]]
+name = "openssl-sys"
+version = "0.9.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e46109c383602735fa0a2e48dd2b7c892b048e1bf69e5c3b1d804b7d9c203cb"
+dependencies = [
+ "autocfg",
+ "cc",
+ "libc",
+ "pkg-config",
+ "vcpkg",
+]
 
 [[package]]
 name = "os_str_bytes"
@@ -305,10 +712,10 @@ version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d58c7c768d4ba344e3e8d72518ac13e259d7c7ade24167003b8488e10b6740a3"
 dependencies = [
- "cfg-if",
+ "cfg-if 0.1.10",
  "cloudabi",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.1.57",
  "smallvec",
  "winapi",
 ]
@@ -318,6 +725,24 @@ name = "percent-encoding"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4fd5641d01c8f18a23da7b6fe29298ff4b55afcccdf78973b24cf3175fee32e"
+
+[[package]]
+name = "pin-project-lite"
+version = "0.2.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e280fbe77cc62c91527259e9442153f4688736748d24660126286329742b4c6c"
+
+[[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkg-config"
+version = "0.3.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
 name = "proc-macro-error"
@@ -353,6 +778,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pubgrub"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdd14552ad5f5d743a323c10d576f26822a044355d6601f377d813ece46f38fd"
+dependencies = [
+ "rustc-hash",
+ "thiserror",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -368,6 +803,68 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41cc0f7e4d5d4544e8861606a285bb08d3e70712ccc7d2b84d7c0ccfaf4b05ce"
 
 [[package]]
+name = "redox_syscall"
+version = "0.2.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "remove_dir_all"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3acd125665422973a33ac9d3dd2df85edad0f4ae9b00dafb1a05e43a9f5ef8e7"
+dependencies = [
+ "winapi",
+]
+
+[[package]]
+name = "reqwest"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87f242f1488a539a79bac6dbe7c8609ae43b7914b7736210f239a37cccb32525"
+dependencies = [
+ "async-compression",
+ "base64",
+ "bytes",
+ "encoding_rs",
+ "futures-core",
+ "futures-util",
+ "h2",
+ "http",
+ "http-body",
+ "hyper",
+ "hyper-tls",
+ "ipnet",
+ "js-sys",
+ "lazy_static",
+ "log",
+ "mime",
+ "native-tls",
+ "percent-encoding",
+ "pin-project-lite",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "tokio",
+ "tokio-native-tls",
+ "tokio-util",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "winreg",
+]
+
+[[package]]
+name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
 name = "rustversion"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -380,10 +877,43 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73b4b750c782965c211b42f022f59af1fbceabdd026623714f104152f1ec149f"
 
 [[package]]
+name = "schannel"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f05ba609c234e60bee0d547fe94a4c7e9da733d1c962cf6e59efa4cd9c8bc75"
+dependencies = [
+ "lazy_static",
+ "winapi",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d29ab0c6d3fc0ee92fe66e2d99f700eab17a8d57d1c1d3b748380fb20baa78cd"
+
+[[package]]
+name = "security-framework"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dc14f172faf8a0194a3aded622712b0de276821addc574fa54fc0a1167e10dc"
+dependencies = [
+ "bitflags",
+ "core-foundation",
+ "core-foundation-sys",
+ "libc",
+ "security-framework-sys",
+]
+
+[[package]]
+name = "security-framework-sys"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0160a13a177a45bfb43ce71c01580998474f556ad854dcbca936dd2841a5c556"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "semver"
@@ -412,6 +942,29 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "serde_json"
+version = "1.0.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e8d9fa5c3b304765ce1fd9c4c8a3de2c8db365a5b91be52f186efc675681d95"
+dependencies = [
+ "itoa",
+ "ryu",
+ "serde",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -450,10 +1003,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "slab"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9def91fd1e018fe007022791f865d0ccc9b3a0d5001e01aabb8b40e46000afb5"
+
+[[package]]
 name = "smallvec"
 version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2dd574626839106c320a323308629dcb1acfc96e32a8cba364ddc61ac23ee83"
+
+[[package]]
+name = "socket2"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66d72b759436ae32898a2af0a14218dbf55efde3feeb170eb623637db85ee1e0"
+dependencies = [
+ "libc",
+ "winapi",
+]
 
 [[package]]
 name = "strsim"
@@ -470,6 +1039,20 @@ dependencies = [
  "proc-macro2",
  "quote",
  "unicode-xid",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5cdb1ef4eaeeaddc8fbd371e5017057064af0911902ef36b39801f67cc6d79e4"
+dependencies = [
+ "cfg-if 1.0.0",
+ "fastrand",
+ "libc",
+ "redox_syscall 0.2.10",
+ "remove_dir_all",
+ "winapi",
 ]
 
 [[package]]
@@ -523,6 +1106,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cda74da7e1a664f795bb1f8a87ec406fb89a02522cf6e50620d016add6dbbf5c"
 
 [[package]]
+name = "tokio"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af73ac49756f3f7c01172e34a23e5d0216f6c32333757c2c61feb2bbff5a5ee"
+dependencies = [
+ "bytes",
+ "libc",
+ "memchr",
+ "mio",
+ "num_cpus",
+ "pin-project-lite",
+ "socket2",
+ "winapi",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f7d995660bd2b7f8c1568414c1126076c13fbb725c40112dc0120b78eb9b717b"
+dependencies = [
+ "native-tls",
+ "tokio",
+]
+
+[[package]]
+name = "tokio-util"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e99e1983e5d376cd8eb4b66604d2e99e79f5bd988c3055891dcd8c9e2604cc0"
+dependencies = [
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "log",
+ "pin-project-lite",
+ "tokio",
+]
+
+[[package]]
+name = "tower-service"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "360dfd1d6d30e05fda32ace2c8c70e9c0a9da713275777f5a4dbb8a1893930c6"
+
+[[package]]
+name = "tracing"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6c650a8ef0cd2dd93736f033d21cbd1224c5a967aa0c258d00fcf7dafef9b9f"
+dependencies = [
+ "cfg-if 1.0.0",
+ "pin-project-lite",
+ "tracing-core",
+]
+
+[[package]]
+name = "tracing-core"
+version = "0.1.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03cfcb51380632a72d3111cb8d3447a8d908e577d31beeac006f836383d29a23"
+dependencies = [
+ "lazy_static",
+]
+
+[[package]]
+name = "try-lock"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
+
+[[package]]
 name = "unicode-bidi"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -557,6 +1212,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
 name = "version_check"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +1230,92 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67fe15bc81afdceeaedd710d237f9043e895fd619db42cb503d9bfbb27a9f3a1"
 dependencies = [
  "thiserror",
+]
+
+[[package]]
+name = "want"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ce8a968cb1cd110d136ff8b819a556d6fb6d919363c61534f6860c7eb172ba0"
+dependencies = [
+ "log",
+ "try-lock",
+]
+
+[[package]]
+name = "wasm-bindgen"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25f1af7423d8588a3d840681122e72e6a24ddbcb3f0ec385cac0d12d24256c06"
+dependencies = [
+ "cfg-if 1.0.0",
+ "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b21c0df030f5a177f3cba22e9bc4322695ec43e7257d865302900290bcdedca"
+dependencies = [
+ "bumpalo",
+ "lazy_static",
+ "log",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2eb6ec270a31b1d3c7e266b999739109abce8b6c87e4b31fcfcd788b65267395"
+dependencies = [
+ "cfg-if 1.0.0",
+ "js-sys",
+ "wasm-bindgen",
+ "web-sys",
+]
+
+[[package]]
+name = "wasm-bindgen-macro"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f4203d69e40a52ee523b2529a773d5ffc1dc0071801c87b3d270b471b80ed01"
+dependencies = [
+ "quote",
+ "wasm-bindgen-macro-support",
+]
+
+[[package]]
+name = "wasm-bindgen-macro-support"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfa8a30d46208db204854cadbb5d4baf5fcf8071ba5bf48190c3e59937962ebc"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wasm-bindgen-backend",
+ "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-shared"
+version = "0.2.79"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d958d035c4438e28c70e4321a2911302f10135ce78a9c7834c0cab4123d06a2"
+
+[[package]]
+name = "web-sys"
+version = "0.3.56"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c060b319f29dd25724f09a2ba1418f142f539b2be99fbf4d2d5a8f7330afb8eb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -607,6 +1354,15 @@ name = "winapi-x86_64-pc-windows-gnu"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "712e227841d057c1ee1cd2fb22fa7e5a5461ae8e48fa2ca79ec42cfc1931183f"
+
+[[package]]
+name = "winreg"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0120db82e8a1e0b9fb3345a539c478767c0048d842860994d96113d5b667bd69"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "yaml-rust"

--- a/PROPOSAL.md
+++ b/PROPOSAL.md
@@ -232,7 +232,7 @@ The manifest has a schema like:
         "name": "A display name for this repository"
     },
     "packages": {
-        "package name" {
+        "package name": {
             "version": {
                 "dependencies": {
                     "dependency": "specifier",
@@ -241,11 +241,11 @@ The manifest has a schema like:
                 "urls": [
                     "an url to download this package at",
                     "another url, equivilant to the first"
-                ]
+                ],
                 "digests": {
                     "sha256": "..."
                 }
-            },
+            }
         }
     }
 }

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -7,8 +7,11 @@ edition = "2021"
 camino = "1.0.7"
 md5 = "0.7.0"
 named-lock = "0.1.1"
+pubgrub = "0.2.1"
+reqwest = { version = "0.11.9", features = ["native-tls", "blocking", "gzip", "json"] }
 semver = { version = "1.0.5", features = ["serde"] }
 serde = { version = "1.0", features = ["derive"] }
+serde_json = "1.0.79"
 serde_with = "1.12.0"
 serde_yaml = "0.8"
 thiserror = "1.0"

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 camino = "1.0.7"
+indexmap = "1.8.0"
 md5 = "0.7.0"
 named-lock = "0.1.1"
 pubgrub = "0.2.1"

--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -31,28 +31,28 @@ pub enum ConfigError {
     NoTargetDirectoryFound,
 }
 
-#[derive(Deserialize, Debug)]
-struct Repository {
-    #[serde(rename = "url")]
-    _url: Url,
+#[derive(Deserialize, Debug, Clone)]
+pub(crate) struct Repository {
+    pub(crate) name: String,
+    pub(crate) url: Url,
 }
 
 impl FromStr for Repository {
     type Err = ConfigError;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let name = s.to_string();
         let url = Url::from_str(s).map_err(|source| ConfigError::InvalidURL { source })?;
 
-        Ok(Repository { _url: url })
+        Ok(Repository { name, url })
     }
 }
 
 #[serde_with::serde_as]
 #[derive(Deserialize, Debug)]
 pub struct Config {
-    #[serde(rename = "repositories")]
     #[serde_as(as = "Vec<PickFirst<(_, DisplayFromStr)>>")]
-    _repositories: Vec<Repository>,
+    repositories: Vec<Repository>,
 }
 
 impl Config {
@@ -66,6 +66,10 @@ impl Config {
             .map_err(|source| ConfigError::InvalidConfig { source })?;
 
         Ok(config)
+    }
+
+    pub(crate) fn repositories(&self) -> &[Repository] {
+        &self.repositories
     }
 }
 

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -201,7 +201,7 @@ impl MQPkg {
     fn resolve(&self) -> Result<resolver::Solution, MQPkgError> {
         let repository = repository::Repository::new()?.fetch(self.config.repositories())?;
         let solver = resolver::Solver::new(repository);
-        let solution = solver.resolve(PackageName(".".to_string()), Version::parse("1.0.0")?)?;
+        let solution = solver.resolve()?;
 
         Ok(solution)
     }

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -198,7 +198,8 @@ impl MQPkg {
                 requested.insert(req.name.clone(), req.version.clone());
             }
 
-            self.resolve(requested)?;
+            // Resolve all of our requirements to a full set of packages that we should install
+            let _solution = self.resolve(requested)?;
         });
 
         Ok(())

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -83,6 +83,10 @@ pub enum VersionError {
 struct Version(SemanticVersion);
 
 impl Version {
+    fn new(major: u64, minor: u64, patch: u64) -> Version {
+        Version(SemanticVersion::new(major, minor, patch))
+    }
+
     fn parse(value: &str) -> Result<Version, VersionError> {
         Version::from_str(value)
     }
@@ -192,9 +196,7 @@ impl MQPkg {
 
 impl MQPkg {
     fn resolve(&self) -> Result<(), MQPkgError> {
-        let mut repository = repository::Repository::new()?;
-        repository.fetch(self.config.repositories())?;
-
+        let repository = repository::Repository::new()?.fetch(self.config.repositories())?;
         let solver = resolver::Solver::new(repository);
         let solution = solver.resolve(PackageName(".".to_string()), Version::parse("1.0.0")?);
 

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -3,11 +3,13 @@
 // for complete details.
 
 use std::clone::Clone;
-use std::cmp::{Eq, PartialEq};
+use std::cmp::{Eq, Ord, PartialEq};
+use std::fmt;
 use std::hash::Hash;
 use std::str::FromStr;
 
-use semver::VersionReq;
+use pubgrub::version::Version as RVersion;
+use semver::{Version as SemanticVersion, VersionReq};
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
 use vfs::VfsPath;
@@ -17,6 +19,8 @@ use crate::pkgdb::transactions::transaction;
 pub mod config;
 
 mod pkgdb;
+mod repository;
+mod resolver;
 
 #[derive(Error, Debug)]
 pub enum PackageNameError {
@@ -32,6 +36,12 @@ pub enum PackageNameError {
 
 #[derive(Serialize, Deserialize, Clone, Eq, Debug, Hash, PartialEq)]
 pub struct PackageName(String);
+
+impl fmt::Display for PackageName {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
 
 impl FromStr for PackageName {
     type Err = PackageNameError;
@@ -60,6 +70,49 @@ impl FromStr for PackageName {
         }
 
         Ok(PackageName(value.to_ascii_lowercase()))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum VersionError {
+    #[error(transparent)]
+    ParseError(#[from] semver::Error),
+}
+
+#[derive(Deserialize, Debug, Clone, Ord, Eq, PartialEq, PartialOrd, Hash)]
+struct Version(SemanticVersion);
+
+impl Version {
+    fn parse(value: &str) -> Result<Version, VersionError> {
+        Version::from_str(value)
+    }
+}
+
+impl FromStr for Version {
+    type Err = VersionError;
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        Ok(Version(SemanticVersion::parse(value)?))
+    }
+}
+
+impl fmt::Display for Version {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "{}", self.0)
+    }
+}
+
+impl RVersion for Version {
+    fn lowest() -> Version {
+        Version(SemanticVersion::new(0, 0, 0))
+    }
+
+    fn bump(&self) -> Version {
+        Version(SemanticVersion::new(
+            self.0.major,
+            self.0.minor,
+            self.0.patch + 1,
+        ))
     }
 }
 
@@ -101,20 +154,27 @@ impl FromStr for PackageSpecifier {
 pub enum MQPkgError {
     #[error(transparent)]
     DBError(#[from] pkgdb::DBError),
+
+    #[error(transparent)]
+    RepositoryError(#[from] repository::RepositoryError),
+
+    #[error(transparent)]
+    VersionError(#[from] VersionError),
 }
 
 pub struct MQPkg {
+    config: config::Config,
     db: pkgdb::Database,
 }
 
 impl MQPkg {
-    pub fn new(_config: config::Config, fs: VfsPath, rid: &str) -> Result<MQPkg, MQPkgError> {
+    pub fn new(config: config::Config, fs: VfsPath, rid: &str) -> Result<MQPkg, MQPkgError> {
         // We're using MD5 here because it's short and fast, we're not using
         // this in a security sensitive aspect.
         let id = format!("{:x}", md5::compute(rid));
         let db = pkgdb::Database::new(fs, id)?;
 
-        Ok(MQPkg { db })
+        Ok(MQPkg { config, db })
     }
 
     pub fn install(&mut self, packages: &[PackageSpecifier]) -> Result<(), MQPkgError> {
@@ -122,7 +182,23 @@ impl MQPkg {
             for package in packages {
                 self.db.add(package)?;
             }
+
+            self.resolve()?;
         });
+
+        Ok(())
+    }
+}
+
+impl MQPkg {
+    fn resolve(&self) -> Result<(), MQPkgError> {
+        let mut repository = repository::Repository::new()?;
+        repository.fetch(self.config.repositories())?;
+
+        let solver = resolver::Solver::new(repository);
+        let solution = solver.resolve(PackageName(".".to_string()), Version::parse("1.0.0")?);
+
+        println!("{:?}", solution);
 
         Ok(())
     }

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -87,10 +87,6 @@ impl Version {
     fn new(major: u64, minor: u64, patch: u64) -> Version {
         Version(SemanticVersion::new(major, minor, patch))
     }
-
-    fn parse(value: &str) -> Result<Version, VersionError> {
-        Version::from_str(value)
-    }
 }
 
 impl FromStr for Version {

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -17,6 +17,8 @@ use vfs::VfsPath;
 
 use crate::pkgdb::transactions::transaction;
 
+pub use crate::resolver::SolverError;
+
 pub mod config;
 
 mod pkgdb;

--- a/mqpkg/src/pkgdb.rs
+++ b/mqpkg/src/pkgdb.rs
@@ -34,10 +34,10 @@ pub enum DBError {
     NoTransaction,
 }
 
-#[derive(Serialize, Deserialize, Debug)]
-struct PackageRequest {
-    name: PackageName,
-    version: VersionReq,
+#[derive(Serialize, Deserialize, Debug, Clone)]
+pub(crate) struct PackageRequest {
+    pub(crate) name: PackageName,
+    pub(crate) version: VersionReq,
 }
 
 #[derive(Serialize, Deserialize, Default, Debug)]
@@ -122,6 +122,10 @@ impl Database {
             },
         );
         Ok(())
+    }
+
+    pub(crate) fn requested(&mut self) -> DBResult<&HashMap<PackageName, PackageRequest>> {
+        Ok(&self.state()?.requested)
     }
 }
 

--- a/mqpkg/src/pkgdb.rs
+++ b/mqpkg/src/pkgdb.rs
@@ -87,17 +87,6 @@ impl Database {
         })
     }
 
-    pub fn add(&mut self, package: &PackageSpecifier) -> DBResult<()> {
-        self.state()?.requested.insert(
-            package.name.clone(),
-            PackageRequest {
-                name: package.name.clone(),
-                version: package.version.clone(),
-            },
-        );
-        Ok(())
-    }
-
     pub(crate) fn transaction(&self) -> DBResult<TransactionManager> {
         Ok(TransactionManager::new(&self.id)?)
     }
@@ -121,6 +110,17 @@ impl Database {
         // parameter.
         drop(txn);
 
+        Ok(())
+    }
+
+    pub(crate) fn add(&mut self, package: &PackageSpecifier) -> DBResult<()> {
+        self.state()?.requested.insert(
+            package.name.clone(),
+            PackageRequest {
+                name: package.name.clone(),
+                version: package.version.clone(),
+            },
+        );
         Ok(())
     }
 }

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -1,0 +1,99 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::collections::HashMap;
+use std::fs::File;
+use std::io::BufReader;
+use std::iter::Iterator;
+
+use reqwest::blocking::Client as HTTPClient;
+use semver::VersionReq;
+use serde::Deserialize;
+use thiserror::Error;
+use url::Url;
+
+use crate::config;
+use crate::{PackageName, Version};
+
+#[derive(Deserialize, Debug)]
+struct MetaData {
+    name: String,
+}
+
+#[derive(Deserialize, Debug)]
+struct PackageData {
+    #[serde(default)]
+    dependencies: HashMap<PackageName, VersionReq>,
+    urls: Vec<Url>,
+    digests: HashMap<String, String>,
+}
+
+#[derive(Deserialize, Debug)]
+pub(super) struct RepoData {
+    meta: MetaData,
+    packages: HashMap<PackageName, HashMap<Version, PackageData>>,
+}
+
+#[derive(Error, Debug)]
+pub enum RepositoryError {
+    #[error(transparent)]
+    HTTPError(#[from] reqwest::Error),
+
+    #[error("could not parse JSON data")]
+    Deserialize(#[from] serde_json::Error),
+
+    #[error("could not access local file")]
+    IoError(#[from] std::io::Error),
+}
+
+#[derive(Debug)]
+pub(crate) struct Repository {
+    client: HTTPClient,
+    data: HashMap<String, RepoData>,
+}
+
+impl Repository {
+    pub(crate) fn new() -> Result<Repository, RepositoryError> {
+        let client = HTTPClient::builder().gzip(true).build()?;
+        let data = HashMap::<String, RepoData>::new();
+
+        Ok(Repository { client, data })
+    }
+
+    pub(crate) fn fetch(&mut self, repos: &[config::Repository]) -> Result<(), RepositoryError> {
+        for repo in repos.iter() {
+            let data: RepoData = match repo.url.scheme() {
+                "file" => {
+                    let file = File::open(repo.url.to_file_path().unwrap())?;
+                    let reader = BufReader::new(file);
+
+                    serde_json::from_reader(reader)?
+                }
+                _ => self
+                    .client
+                    .get(repo.url.clone())
+                    .send()?
+                    .error_for_status()?
+                    .json()?,
+            };
+            self.data.insert(repo.name.clone(), data);
+        }
+
+        Ok(())
+    }
+
+    pub(crate) fn versions(&self, package: &PackageName) -> impl Iterator<Item = Version> {
+        let mut versions = Vec::<Version>::new();
+
+        versions.into_iter()
+    }
+
+    pub(crate) fn dependencies(
+        &self,
+        package: &PackageName,
+        version: &Version,
+    ) -> Result<HashMap<PackageName, VersionReq>, RepositoryError> {
+        Ok(HashMap::new())
+    }
+}

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -91,7 +91,7 @@ impl Repository {
         Ok(self)
     }
 
-    pub(crate) fn versions(&self, package: &PackageName) -> impl Iterator<Item = Version> {
+    pub(crate) fn versions(&self, package: &PackageName) -> Vec<Version> {
         let mut versions = Vec::<Version>::new();
         let mut seen = HashSet::<Version>::new();
 
@@ -109,7 +109,7 @@ impl Repository {
         // We want to put the newest version first, this will make sure that our resolver
         // will do intelligent things, like trying the newest version.
         versions.sort_unstable_by(|l, r| l.cmp(r).reverse());
-        versions.into_iter()
+        versions
     }
 
     pub(crate) fn dependencies(

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -31,20 +31,24 @@ pub enum RepositoryError {
 
 #[derive(Deserialize, Debug)]
 struct MetaData {
-    name: String,
+    #[serde(rename = "name")]
+    _name: String,
 }
 
 #[derive(Deserialize, Debug)]
 struct Release {
     #[serde(default)]
     dependencies: HashMap<PackageName, VersionReq>,
-    urls: Vec<Url>,
-    digests: HashMap<String, String>,
+    #[serde(rename = "urls")]
+    _urls: Vec<Url>,
+    #[serde(rename = "digests")]
+    _digests: HashMap<String, String>,
 }
 
 #[derive(Deserialize, Debug)]
 pub(super) struct RepoData {
-    meta: MetaData,
+    #[serde(rename = "meta")]
+    _meta: MetaData,
     packages: HashMap<PackageName, HashMap<Version, Release>>,
 }
 

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -5,7 +5,6 @@
 use std::collections::{HashMap, HashSet};
 use std::fs::File;
 use std::io::BufReader;
-use std::iter::Iterator;
 
 use indexmap::IndexMap;
 use reqwest::blocking::Client as HTTPClient;

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -1,0 +1,63 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::borrow::Borrow;
+use std::error::Error;
+
+use pubgrub::error::PubGrubError;
+use pubgrub::range::Range;
+use pubgrub::solver::{
+    choose_package_with_fewest_versions, resolve, Dependencies, DependencyConstraints,
+    DependencyProvider, OfflineDependencyProvider,
+};
+use pubgrub::type_aliases::SelectedDependencies;
+// use pubgrub::version::Version;
+
+use crate::repository::Repository;
+use crate::{PackageName, Version};
+
+pub(crate) struct Solver {
+    provider: OfflineDependencyProvider<PackageName, Version>,
+    repository: Repository,
+}
+
+impl Solver {
+    pub(crate) fn new(repository: Repository) -> Solver {
+        let provider = OfflineDependencyProvider::new();
+        Solver {
+            provider,
+            repository,
+        }
+    }
+
+    pub(crate) fn resolve(
+        &self,
+        package: PackageName,
+        version: Version,
+    ) -> Result<SelectedDependencies<PackageName, Version>, PubGrubError<PackageName, Version>>
+    {
+        resolve(self, package, version)
+    }
+}
+
+impl DependencyProvider<PackageName, Version> for Solver {
+    fn choose_package_version<T: Borrow<PackageName>, U: Borrow<Range<Version>>>(
+        &self,
+        potential_packages: impl Iterator<Item = (T, U)>,
+    ) -> Result<(T, Option<Version>), Box<dyn Error>> {
+        Ok(choose_package_with_fewest_versions(
+            |p| self.repository.versions(p),
+            potential_packages,
+        ))
+    }
+
+    fn get_dependencies(
+        &self,
+        package: &PackageName,
+        version: &Version,
+    ) -> Result<Dependencies<PackageName, Version>, Box<dyn Error>> {
+        let deps = DependencyConstraints::<PackageName, Version>::default();
+        Ok(Dependencies::Known(deps))
+    }
+}

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -32,9 +32,6 @@ const ROOT_VER: (u64, u64, u64) = (1, 0, 0);
 pub enum SolverError {
     #[error("No solution")]
     NoSolution(Box<DerivedResult>),
-
-    #[error("noop")]
-    Noop,
 }
 
 impl SolverError {

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -3,32 +3,26 @@
 // for complete details.
 
 use std::borrow::Borrow;
-use std::error::Error;
 
 use pubgrub::error::PubGrubError;
 use pubgrub::range::Range;
 use pubgrub::solver::{
     choose_package_with_fewest_versions, resolve, Dependencies, DependencyConstraints,
-    DependencyProvider, OfflineDependencyProvider,
+    DependencyProvider,
 };
 use pubgrub::type_aliases::SelectedDependencies;
-// use pubgrub::version::Version;
+use thiserror::Error;
 
 use crate::repository::Repository;
 use crate::{PackageName, Version};
 
 pub(crate) struct Solver {
-    provider: OfflineDependencyProvider<PackageName, Version>,
     repository: Repository,
 }
 
 impl Solver {
     pub(crate) fn new(repository: Repository) -> Solver {
-        let provider = OfflineDependencyProvider::new();
-        Solver {
-            provider,
-            repository,
-        }
+        Solver { repository }
     }
 
     pub(crate) fn resolve(
@@ -45,7 +39,7 @@ impl DependencyProvider<PackageName, Version> for Solver {
     fn choose_package_version<T: Borrow<PackageName>, U: Borrow<Range<Version>>>(
         &self,
         potential_packages: impl Iterator<Item = (T, U)>,
-    ) -> Result<(T, Option<Version>), Box<dyn Error>> {
+    ) -> Result<(T, Option<Version>), Box<dyn std::error::Error>> {
         Ok(choose_package_with_fewest_versions(
             |p| self.repository.versions(p),
             potential_packages,
@@ -56,8 +50,215 @@ impl DependencyProvider<PackageName, Version> for Solver {
         &self,
         package: &PackageName,
         version: &Version,
-    ) -> Result<Dependencies<PackageName, Version>, Box<dyn Error>> {
-        let deps = DependencyConstraints::<PackageName, Version>::default();
+    ) -> Result<Dependencies<PackageName, Version>, Box<dyn std::error::Error>> {
+        let mut deps = DependencyConstraints::<PackageName, Version>::default();
+
+        for (dep, req) in self.repository.dependencies(package, version) {
+            for comp in req.comparators.iter() {
+                match convert(comp) {
+                    Ok(new) => merge(&mut deps, &dep, new),
+                    Err(e) => match e {
+                        ComparatorError::InvalidVersion => {
+                            panic!("version with no minor but a patch: {:?}", req)
+                        }
+                        ComparatorError::UnknownOperator => {
+                            panic!("unknown semver operator: {:?}", req)
+                        }
+                        ComparatorError::InvalidWildcard => {
+                            panic!("invalid wildcard: {:?}", req)
+                        }
+                    },
+                }
+            }
+        }
+
         Ok(Dependencies::Known(deps))
+    }
+}
+
+fn merge(
+    deps: &mut DependencyConstraints<PackageName, Version>,
+    package: &PackageName,
+    new: Range<Version>,
+) {
+    let existing = deps.get(package);
+    let merged = match existing {
+        Some(other) => new.intersection(other),
+        None => new,
+    };
+    deps.insert(package.clone(), merged);
+}
+
+#[derive(Error, Debug)]
+pub enum ComparatorError {
+    #[error("version with no minor but a patch")]
+    InvalidVersion,
+
+    #[error("unknown operator")]
+    UnknownOperator,
+
+    #[error("wildcard with patch version")]
+    InvalidWildcard,
+}
+
+fn convert(comp: &semver::Comparator) -> Result<Range<Version>, ComparatorError> {
+    let major = comp.major;
+    match comp.op {
+        semver::Op::Exact => {
+            match (comp.minor, comp.patch) {
+                //  =I.J.K — exactly the version I.J.K
+                (Some(minor), Some(patch)) => Ok(Range::exact(Version::new(major, minor, patch))),
+                // =I.J — equivalent to >=I.J.0, <I.(J+1).0
+                (Some(minor), None) => Ok(Range::between(
+                    Version::new(major, minor, 0),
+                    Version::new(major, minor + 1, 0),
+                )),
+                // =I — equivalent to >=I.0.0, <(I+1).0.0
+                (None, None) => Ok(Range::between(
+                    Version::new(major, 0, 0),
+                    Version::new(major + 1, 0, 0),
+                )),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::Greater => {
+            match (comp.minor, comp.patch) {
+                // >I.J.K
+                (Some(minor), Some(patch)) => {
+                    Ok(Range::higher_than(Version::new(major, minor, patch + 1)))
+                }
+                // >I.J — equivalent to >=I.(J+1).0
+                (Some(minor), None) => Ok(Range::higher_than(Version::new(major, minor + 1, 0))),
+                // >I — equivalent to >=(I+1).0.0
+                (None, None) => Ok(Range::higher_than(Version::new(major + 1, 0, 0))),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::GreaterEq => {
+            match (comp.minor, comp.patch) {
+                //  >=I.J.K
+                (Some(minor), Some(patch)) => {
+                    Ok(Range::higher_than(Version::new(major, minor, patch)))
+                }
+                // >=I.J — equivalent to >=I.J.0
+                (Some(minor), None) => Ok(Range::higher_than(Version::new(major, minor, 0))),
+                // >=I — equivalent to >=I.0.0
+                (None, None) => Ok(Range::higher_than(Version::new(major, 0, 0))),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::Less => {
+            match (comp.minor, comp.patch) {
+                // <I.J.K
+                (Some(minor), Some(patch)) => Ok(Range::strictly_lower_than(Version::new(
+                    major, minor, patch,
+                ))),
+                // <I.J — equivalent to <I.J.0
+                (Some(minor), None) => {
+                    Ok(Range::strictly_lower_than(Version::new(major, minor, 0)))
+                }
+                // <I — equivalent to <I.0.0
+                (None, None) => Ok(Range::strictly_lower_than(Version::new(major, 0, 0))),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::LessEq => {
+            match (comp.minor, comp.patch) {
+                // <=I.J.K — equivalent to <I.J.(K+1)
+                (Some(minor), Some(patch)) => Ok(Range::strictly_lower_than(Version::new(
+                    major,
+                    minor,
+                    patch + 1,
+                ))),
+                // <=I.J — equivalent to <I.(J+1).0
+                (Some(minor), None) => Ok(Range::strictly_lower_than(Version::new(
+                    major,
+                    minor + 1,
+                    0,
+                ))),
+                // <=I — equivalent to <(I+1).0.0
+                (None, None) => Ok(Range::strictly_lower_than(Version::new(major + 1, 0, 0))),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::Tilde => {
+            match (comp.minor, comp.patch) {
+                // ~I.J.K — equivalent to >=I.J.K, <I.(J+1).0
+                (Some(minor), Some(patch)) => Ok(Range::between(
+                    Version::new(major, minor, patch),
+                    Version::new(major, minor + 1, 0),
+                )),
+                // ~I.J — equivalent to =I.J
+                (Some(minor), None) => Ok(Range::between(
+                    Version::new(major, minor, 0),
+                    Version::new(major, minor + 1, 0),
+                )),
+                // ~I — equivalent to =I
+                (None, None) => Ok(Range::between(
+                    Version::new(major, 0, 0),
+                    Version::new(major + 1, 0, 0),
+                )),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::Caret => {
+            match (comp.minor, comp.patch) {
+                (Some(minor), Some(patch)) => {
+                    if major > 0 {
+                        // ^I.J.K (for I>0) — equivalent to >=I.J.K, <(I+1).0.0
+                        Ok(Range::between(
+                            Version::new(major, minor, patch),
+                            Version::new(major + 1, 0, 0),
+                        ))
+                    } else if minor > 0 {
+                        // ^0.J.K (for J>0) — equivalent to >=0.J.K, <0.(J+1).0
+                        assert!(major == 0);
+                        Ok(Range::between(
+                            Version::new(0, minor, patch),
+                            Version::new(0, minor + 1, 0),
+                        ))
+                    } else {
+                        // ^0.0.K — equivalent to =0.0.K
+                        assert!(major == 0 && minor == 0);
+                        Ok(Range::exact(Version::new(0, 0, patch)))
+                    }
+                }
+                (Some(minor), None) => {
+                    if major > 0 || minor > 0 {
+                        // ^I.J (for I>0 or J>0) — equivalent to ^I.J.0
+                        Ok(Range::between(
+                            Version::new(major, minor, 0),
+                            Version::new(major + 1, 0, 0),
+                        ))
+                    } else {
+                        // ^0.0 — equivalent to =0.0
+                        assert!(major == 0 && minor == 0);
+                        Ok(Range::between(
+                            Version::new(major, minor, 0),
+                            Version::new(major, minor + 1, 0),
+                        ))
+                    }
+                }
+                // ^I — equivalent to =I
+                (None, None) => Ok(Range::between(
+                    Version::new(major, 0, 0),
+                    Version::new(major + 1, 0, 0),
+                )),
+                _ => Err(ComparatorError::InvalidVersion),
+            }
+        }
+        semver::Op::Wildcard => match (comp.minor, comp.patch) {
+            (Some(_), Some(_)) => Err(ComparatorError::InvalidWildcard),
+            (Some(minor), None) => Ok(Range::between(
+                Version::new(major, minor, 0),
+                Version::new(major, minor + 1, 0),
+            )),
+            (None, None) => Ok(Range::between(
+                Version::new(major, 0, 0),
+                Version::new(major + 1, 0, 0),
+            )),
+            _ => Err(ComparatorError::InvalidVersion),
+        },
+        _ => Err(ComparatorError::UnknownOperator),
     }
 }

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -43,11 +43,17 @@ impl Solver {
         Solver { repository }
     }
 
-    pub(crate) fn resolve(
-        &self,
-        package: PackageName,
-        version: Version,
-    ) -> Result<Solution, SolverError> {
+    pub(crate) fn resolve(&self) -> Result<Solution, SolverError> {
+        // Note: The name used here **MUST** be an invalid name for packages to have,
+        //       if it's not, then our root package (which represents this stuff the
+        //       used has asked for) will collide with a real package.
+        let package = PackageName(":root:".to_string());
+
+        // Note: The actual version doesn't matter here. This is just a marker so that
+        //       we can resolve the packages that the user has depended on.
+        let version = Version::new(1, 0, 0);
+
+        // Actually run things through the pubgrub resolver.
         resolve(self, package, version).map_err(SolverError::from_pubgrub)
     }
 }


### PR DESCRIPTION
Now when someone does ``mqpkg install ...``, after adding the newly requested packages to our stored set of all packages ever requested (in this case, requested means an end user initiated an install of them directly, they were not pulled in automatically), we contact all of our configured repositories, and attempt to resolve the entire dependency chain into a closure of packages that should be installed (they may or may not already be installed).

Due to some limitations in the pubgrub library, this currently does not handle pre-release versions at all. There is a branch of that library that implements the changes that would allow that (and other things) but it is unclear if that is good enough to be used yet or not.

For now we'll just support only "final" versions (e.g. ``I.J.K``) until we have a test suite written that we can exercise to see if that branch will caused us any problems.

We also currently assume that the metadata for a (Package, Version) pair is globally consistent. This is a bad assumption, and we should refactor this so that we're resolving on (Package, Version, Source) triplets (source being the repo name OR local disk). This *might* require the same in progress pull request on pubgrub from above.

On error, we print out pretty decent debugging information. For instance, here's a package where example has 3 versions. and they all depend on a version of mydep that doesn't exist:

```
$ mqpk install example
Error: unable to resolve packages to a set that satisfies all requirements

Because example [ 0.0.0, 1.0.2 [  [ 1.0.3, 1.0.5 [  [ 1.0.6, ∞ [ depends on mydep 1.0.0 <= v and example 1.0.2 depends on mydep 1.0.0 <= v, example [ 0.0.0, 1.0.5 [  [ 1.0.6, ∞ [ is forbidden.
And because example 1.0.5 depends on mydep 1.0.0 <= v and :requested: 1.0.0 depends on example, :requested: 1.0.0 is forbidden.
```

Or a more complicated example, where the example packages all depend on mydep 0.5.0 and anotherdep 0.4.0, but mydep depends on anotherdep 0.5.0.. which means the dependencies are incompatible and are not resolvable:

```
$ mqpk install example
Error: unable to resolve packages to a set that satisfies all requirements

Because mydep depends on anotherdep 0.5.0 and example 1.0.0 depends on mydep, example 1.0.0 depends on anotherdep 0.5.0.
And because example 1.0.0 depends on anotherdep 0.4.0, example 1.0.0 is forbidden. (1)

Because mydep depends on anotherdep 0.5.0 and example 1.0.2 depends on mydep, example 1.0.2 depends on anotherdep 0.5.0.
And because example 1.0.2 depends on anotherdep 0.4.0, example 1.0.2 is forbidden.
And because example 1.0.0 is forbidden (1), example [ 0.0.0, 1.0.5 [  [ 1.0.6, ∞ [ is forbidden. (2)

Because mydep depends on anotherdep 0.5.0 and example 1.0.5 depends on mydep, example 1.0.5 depends on anotherdep 0.5.0.
And because example 1.0.5 depends on anotherdep 0.4.0, example 1.0.5 is forbidden.
And because example [ 0.0.0, 1.0.5 [  [ 1.0.6, ∞ [ is forbidden (2), example ∗ is forbidden.
And because :requested: 1.0.0 depends on example, :requested: 1.0.0 is forbidden.
```

In these examples ``:requested: 1.0.0`` is the metapackage that depends on all of the things that the user has asked to install. It's purposely kept to be an invalid name so that it can never clash with any real package. However it would be nice to rework that part to ouput something less confusing then a weirdly named package with a version number that the user will never otherwise see.