### PR TITLE
Implement a UI and Logging Framework

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -644,6 +644,7 @@ name = "mqpkg"
 version = "0.1.0"
 dependencies = [
  "camino",
+ "console",
  "indexmap",
  "log",
  "md5",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
+name = "aho-corasick"
+version = "0.7.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
 name = "anyhow"
 version = "1.0.54"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +237,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "env_logger"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44533bbbb3bb3c1fa17d9f2e4e38bbbaf8396ba82193c4cb1b6445d711445d36"
+dependencies = [
+ "atty",
+ "humantime",
+ "log",
+ "regex",
+ "termcolor",
+]
+
+[[package]]
 name = "fastrand"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -400,6 +422,15 @@ name = "httpdate"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4a1e36c821dbe04574f602848a19f742f4fb3c98d40449f11bcad18d6b17421"
+
+[[package]]
+name = "humantime"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df004cfca50ef23c36850aaaa59ad52cc70d0e90243c3c7737a4dd32dc7a3c4f"
+dependencies = [
+ "quick-error",
+]
 
 [[package]]
 name = "hyper"
@@ -604,6 +635,7 @@ version = "0.1.0"
 dependencies = [
  "camino",
  "indexmap",
+ "log",
  "md5",
  "named-lock",
  "pubgrub",
@@ -627,7 +659,9 @@ dependencies = [
  "clap",
  "dunce",
  "indicatif",
+ "log",
  "mqpkg",
+ "pretty_env_logger",
  "vfs",
 ]
 
@@ -785,6 +819,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58893f751c9b0412871a09abd62ecd2a00298c6c83befa223ef98c52aef40cbe"
 
 [[package]]
+name = "pretty_env_logger"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "926d36b9553851b8b0005f1275891b392ee4d2d833852c417ed025477350fb9d"
+dependencies = [
+ "env_logger",
+ "log",
+]
+
+[[package]]
 name = "proc-macro-error"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +872,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -857,6 +907,8 @@ version = "1.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
 dependencies = [
+ "aho-corasick",
+ "memchr",
  "regex-syntax",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -132,6 +132,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "console"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a28b32d32ca44b70c3e4acd7db1babf555fa026e385fb95f18028f88848b3c31"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "once_cell",
+ "regex",
+ "terminal_size",
+ "unicode-width",
+ "winapi",
+]
+
+[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -196,6 +211,12 @@ name = "dunce"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "453440c271cf5577fd2a40e4942540cb7d0d2f85e27c8d07dd0023c925a67541"
+
+[[package]]
+name = "encode_unicode"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
@@ -445,6 +466,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.17.0-rc.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04a9b1bacd1a40927c953c5c4485089d8ecc9642cb03e7734eac8a74e8c5b508"
+dependencies = [
+ "console",
+ "number_prefix",
+ "unicode-width",
+]
+
+[[package]]
 name = "instant"
 version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,6 +626,7 @@ dependencies = [
  "camino",
  "clap",
  "dunce",
+ "indicatif",
  "mqpkg",
  "vfs",
 ]
@@ -648,6 +681,12 @@ dependencies = [
  "hermit-abi",
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "once_cell"
@@ -811,6 +850,21 @@ checksum = "8383f39639269cde97d255a32bdb68c047337295414940c68bdd30c2e13203ff"
 dependencies = [
  "bitflags",
 ]
+
+[[package]]
+name = "regex"
+version = "1.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d07a8629359eb56f1e2fb1652bb04212c072a87ba68546a04065d525673ac461"
+dependencies = [
+ "regex-syntax",
+]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f497285884f3fcff424ffc933e56d7cbca511def0c9831a7f9b5f6153e3cc89b"
 
 [[package]]
 name = "remove_dir_all"
@@ -1066,6 +1120,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "terminal_size"
+version = "0.1.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633c1a546cee861a1a6d0dc69ebeca693bf4296661ba7852b9d21d159e0506df"
+dependencies = [
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "textwrap"
 version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1192,6 +1256,12 @@ checksum = "d54590932941a9e9266f0832deed84ebe1bf2e4c9e4a3554d393d18f5e854bf9"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-width"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ed742d4ea2bd1176e236172c8429aaf54486e7ac098db29ffe6529e0ce50973"
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -668,6 +668,7 @@ dependencies = [
  "camino",
  "clap",
  "clap-verbosity-flag",
+ "console",
  "dunce",
  "indicatif",
  "log",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -119,6 +119,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap-verbosity-flag"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "17e437250f23cdd03daf3de763093aa27873a026ef9a156800da9ddd617c51d4"
+dependencies = [
+ "clap",
+ "log",
+]
+
+[[package]]
 name = "clap_derive"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -657,6 +667,7 @@ dependencies = [
  "anyhow",
  "camino",
  "clap",
+ "clap-verbosity-flag",
  "dunce",
  "indicatif",
  "log",

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -12,6 +12,7 @@ mqpkg = { path = "../mqpkg" }
 anyhow = "1.0"
 camino = "1.0.7"
 clap = { version = "3.1.0", features = ["derive"] }
+clap-verbosity-flag = "1.0.0"
 dunce = "1.0.2"
 indicatif = "0.17.0-rc.5"
 log = { version = "0.4", features = ["std"] }

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -14,4 +14,6 @@ camino = "1.0.7"
 clap = { version = "3.1.0", features = ["derive"] }
 dunce = "1.0.2"
 indicatif = "0.17.0-rc.5"
+log = { version = "0.4", features = ["std"] }
+pretty_env_logger = "0.4.0"
 vfs = "0.5.2"

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -13,4 +13,5 @@ anyhow = "1.0"
 camino = "1.0.7"
 clap = { version = "3.1.0", features = ["derive"] }
 dunce = "1.0.2"
+indicatif = "0.17.0-rc.5"
 vfs = "0.5.2"

--- a/mqpkg-cli/Cargo.toml
+++ b/mqpkg-cli/Cargo.toml
@@ -13,6 +13,7 @@ anyhow = "1.0"
 camino = "1.0.7"
 clap = { version = "3.1.0", features = ["derive"] }
 clap-verbosity-flag = "1.0.0"
+console = "0.15.0"
 dunce = "1.0.2"
 indicatif = "0.17.0-rc.5"
 log = { version = "0.4", features = ["std"] }

--- a/mqpkg-cli/src/logging.rs
+++ b/mqpkg-cli/src/logging.rs
@@ -8,20 +8,17 @@ use indicatif::WeakProgressBar;
 use log::{Metadata, Record};
 use pretty_env_logger::env_logger::Logger;
 
-pub(crate) struct IndicatifAwareLogger {
+struct IndicatifAwareLogger {
     internal: Logger,
     bars: Arc<Mutex<Vec<WeakProgressBar>>>,
 }
 
 impl IndicatifAwareLogger {
-    pub(crate) fn new(
-        internal: Logger,
-        bars: Arc<Mutex<Vec<WeakProgressBar>>>,
-    ) -> IndicatifAwareLogger {
+    fn new(internal: Logger, bars: Arc<Mutex<Vec<WeakProgressBar>>>) -> IndicatifAwareLogger {
         IndicatifAwareLogger { internal, bars }
     }
 
-    pub(crate) fn install(self) {
+    fn install(self) {
         let max_level = self.internal.filter();
 
         log::set_boxed_logger(Box::new(self)).unwrap();
@@ -63,4 +60,15 @@ impl log::Log for IndicatifAwareLogger {
     }
 
     fn flush(&self) {}
+}
+
+pub(crate) fn setup(bars: Arc<Mutex<Vec<WeakProgressBar>>>) {
+    let logger = IndicatifAwareLogger::new(
+        pretty_env_logger::formatted_builder()
+            .filter_level(log::LevelFilter::Trace)
+            .build(),
+        bars,
+    );
+
+    logger.install();
 }

--- a/mqpkg-cli/src/logging.rs
+++ b/mqpkg-cli/src/logging.rs
@@ -5,7 +5,7 @@
 use std::sync::{Arc, Mutex};
 
 use indicatif::WeakProgressBar;
-use log::{Metadata, Record};
+use log::{LevelFilter, Metadata, Record};
 use pretty_env_logger::env_logger::Logger;
 
 struct IndicatifAwareLogger {
@@ -62,10 +62,10 @@ impl log::Log for IndicatifAwareLogger {
     fn flush(&self) {}
 }
 
-pub(crate) fn setup(bars: Arc<Mutex<Vec<WeakProgressBar>>>) {
+pub(crate) fn setup(level: LevelFilter, bars: Arc<Mutex<Vec<WeakProgressBar>>>) {
     let logger = IndicatifAwareLogger::new(
         pretty_env_logger::formatted_builder()
-            .filter_level(log::LevelFilter::Trace)
+            .filter_level(level)
             .build(),
         bars,
     );

--- a/mqpkg-cli/src/logging.rs
+++ b/mqpkg-cli/src/logging.rs
@@ -1,0 +1,66 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::sync::{Arc, Mutex};
+
+use indicatif::WeakProgressBar;
+use log::{Metadata, Record};
+use pretty_env_logger::env_logger::Logger;
+
+pub(crate) struct IndicatifAwareLogger {
+    internal: Logger,
+    bars: Arc<Mutex<Vec<WeakProgressBar>>>,
+}
+
+impl IndicatifAwareLogger {
+    pub(crate) fn new(
+        internal: Logger,
+        bars: Arc<Mutex<Vec<WeakProgressBar>>>,
+    ) -> IndicatifAwareLogger {
+        IndicatifAwareLogger { internal, bars }
+    }
+
+    pub(crate) fn install(self) {
+        let max_level = self.internal.filter();
+
+        log::set_boxed_logger(Box::new(self)).unwrap();
+        log::set_max_level(max_level);
+    }
+
+    fn suspended(&self, callback: impl FnOnce()) {
+        let mut bs = self.bars.lock().unwrap();
+        bs.retain(|b| b.upgrade().is_some());
+
+        let mut ibar = bs.iter().filter(|bar| match bar.upgrade() {
+            Some(b) => !b.is_finished(),
+            None => false,
+        });
+        let wbar = ibar.next();
+
+        match wbar {
+            Some(wbar) => {
+                let nbars = ibar.count();
+                assert!(nbars == 0, "too many active bars");
+
+                match wbar.upgrade() {
+                    Some(bar) => bar.suspend(callback),
+                    None => (callback)(),
+                }
+            }
+            None => (callback)(),
+        }
+    }
+}
+
+impl log::Log for IndicatifAwareLogger {
+    fn enabled(&self, metadata: &Metadata) -> bool {
+        self.internal.enabled(metadata)
+    }
+
+    fn log(&self, record: &Record) {
+        self.suspended(|| self.internal.log(record))
+    }
+
+    fn flush(&self) {}
+}

--- a/mqpkg-cli/src/main.rs
+++ b/mqpkg-cli/src/main.rs
@@ -82,6 +82,13 @@ fn main() -> Result<()> {
             b.push(bar.downgrade());
             bar
         });
+        pkg.with_progress_spinner(|msg| {
+            let mut b = bars.lock().unwrap();
+            let bar = ProgressBar::new_spinner();
+            bar.set_message(msg);
+            b.push(bar.downgrade());
+            bar
+        });
         pkg.with_progress_update(|bar, delta| bar.inc(delta));
         pkg.with_progress_finish(|bar| bar.finish_and_clear());
     }

--- a/mqpkg-cli/src/main.rs
+++ b/mqpkg-cli/src/main.rs
@@ -8,7 +8,7 @@ use std::sync::{Arc, Mutex};
 use anyhow::{anyhow, Context, Result};
 use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
-use clap_verbosity_flag::{LogLevel as BaseLogLevel, Verbosity};
+use clap_verbosity_flag::{Verbosity, WarnLevel};
 use indicatif::{ProgressBar, ProgressStyle};
 use log::info;
 use vfs::{PhysicalFS, VfsPath};
@@ -19,20 +19,11 @@ mod logging;
 
 const LOGNAME: &str = "mqpkg";
 
-#[derive(Debug)]
-struct LogLevel;
-
-impl BaseLogLevel for LogLevel {
-    fn default() -> Option<log::Level> {
-        Some(log::Level::Info)
-    }
-}
-
 #[derive(Debug, Parser)]
 #[clap(version)]
 struct Cli {
     #[clap(flatten)]
-    verbose: Verbosity<LogLevel>,
+    verbose: Verbosity<WarnLevel>,
 
     #[clap(global = true, short, long)]
     target: Option<Utf8PathBuf>,
@@ -60,8 +51,8 @@ fn main() -> Result<()> {
     let bars = Arc::new(Mutex::new(Vec::new()));
 
     // Setup our logging.
-    let render_bars = cli.verbose.log_level().or(Some(log::Level::Error)).unwrap()
-        >= LogLevel::default().unwrap();
+    let render_bars =
+        cli.verbose.log_level().or(Some(log::Level::Error)).unwrap() >= log::Level::Warn;
     logging::setup(cli.verbose.log_level_filter(), bars.clone());
 
     // Build our VFS, Config, and Installer objects, and a HashMap to hold our

--- a/mqpkg-cli/src/main.rs
+++ b/mqpkg-cli/src/main.rs
@@ -10,11 +10,14 @@ use camino::Utf8PathBuf;
 use clap::{Parser, Subcommand};
 use clap_verbosity_flag::{LogLevel as BaseLogLevel, Verbosity};
 use indicatif::{ProgressBar, ProgressStyle};
+use log::info;
 use vfs::{PhysicalFS, VfsPath};
 
 use mqpkg::{Config, Installer, InstallerError, PackageSpecifier, SolverError};
 
 mod logging;
+
+const LOGNAME: &str = "mqpkg";
 
 #[derive(Debug)]
 struct LogLevel;
@@ -72,6 +75,7 @@ fn main() -> Result<()> {
             )
         })?,
     };
+    info!(target: LOGNAME, "using root directory: '{}'", root);
     let fs: VfsPath = PhysicalFS::new(PathBuf::from(&root)).into();
     let config =
         Config::load(&fs).with_context(|| format!("invalid target directory '{}'", root))?;

--- a/mqpkg-cli/src/main.rs
+++ b/mqpkg-cli/src/main.rs
@@ -81,7 +81,9 @@ fn main() -> Result<()> {
     // Setup our console callback
     if !cli.verbose.is_silent() {
         pkg.with_console(|msg| {
-            term.write_line(msg).ok();
+            bars.suspended(|| {
+                term.write_line(msg).ok();
+            });
         });
     }
 

--- a/mqpkg-cli/src/progress.rs
+++ b/mqpkg-cli/src/progress.rs
@@ -1,0 +1,55 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use indicatif::{ProgressBar, WeakProgressBar};
+use std::sync::{Arc, Mutex};
+
+pub(crate) struct SuspendableBars {
+    bars: Arc<Mutex<Vec<WeakProgressBar>>>,
+}
+
+impl Clone for SuspendableBars {
+    fn clone(&self) -> SuspendableBars {
+        SuspendableBars {
+            bars: self.bars.clone(),
+        }
+    }
+}
+
+impl SuspendableBars {
+    pub(crate) fn new() -> SuspendableBars {
+        SuspendableBars {
+            bars: Arc::new(Mutex::new(Vec::new())),
+        }
+    }
+
+    pub(crate) fn with_bar(&self, bar: ProgressBar) -> ProgressBar {
+        self.bars.lock().unwrap().push(bar.downgrade());
+        bar
+    }
+
+    pub(crate) fn suspended(&self, callback: impl FnOnce()) {
+        let mut bs = self.bars.lock().unwrap();
+        bs.retain(|b| b.upgrade().is_some());
+
+        let mut ibar = bs.iter().filter(|bar| match bar.upgrade() {
+            Some(b) => !b.is_finished(),
+            None => false,
+        });
+        let wbar = ibar.next();
+
+        match wbar {
+            Some(wbar) => {
+                let nbars = ibar.count();
+                assert!(nbars == 0, "too many active bars");
+
+                match wbar.upgrade() {
+                    Some(bar) => bar.suspend(callback),
+                    None => (callback)(),
+                }
+            }
+            None => (callback)(),
+        }
+    }
+}

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 camino = "1.0.7"
+console = "0.15.0"
 indexmap = "1.8.0"
 log = { version = "0.4", features = ["std"] }
 md5 = "0.7.0"

--- a/mqpkg/Cargo.toml
+++ b/mqpkg/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 camino = "1.0.7"
 indexmap = "1.8.0"
+log = { version = "0.4", features = ["std"] }
 md5 = "0.7.0"
 named-lock = "0.1.1"
 pubgrub = "0.2.1"

--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -5,12 +5,15 @@
 use std::str::FromStr;
 
 use camino::Utf8PathBuf;
+use log::info;
 use serde::Deserialize;
 use serde_with::{serde_as, DisplayFromStr, PickFirst};
 use url::Url;
 use vfs::VfsPath;
 
 use crate::errors::ConfigError;
+
+const LOGNAME: &str = "mqpkg::config";
 
 const CONFIG_FILENAME: &str = "mqpkg.yml";
 
@@ -46,9 +49,15 @@ impl Config {
     }
 
     pub fn load(root: &VfsPath) -> Result<Config> {
-        let file = root
+        let filename = root
             .join(CONFIG_FILENAME)
-            .map_err(|source| ConfigError::NoConfig { source })?
+            .map_err(|source| ConfigError::NoConfig { source })?;
+        info!(
+            target: LOGNAME,
+            "loading config from {:?}",
+            filename.as_str()
+        );
+        let file = filename
             .open_file()
             .map_err(|source| ConfigError::NoConfig { source })?;
         let config: Config = serde_yaml::from_reader(file)

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -5,6 +5,7 @@
 use std::clone::Clone;
 use std::collections::HashMap;
 
+use log::info;
 use vfs::VfsPath;
 
 use crate::pkgdb::transaction;
@@ -78,7 +79,15 @@ impl<'p, T> Installer<'p, T> {
             let bar = self.progress.bar(30);
             for _ in 0..30 {
                 std::thread::sleep(std::time::Duration::from_millis(250));
-                // info!(target: "mqpkg", "test");
+                info!(target: "mqpkg", "test");
+                bar.update(1);
+            }
+            bar.finish();
+
+            let bar = self.progress.bar(30);
+            for _ in 0..30 {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                info!(target: "mqpkg", "test");
                 bar.update(1);
             }
             bar.finish();

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -24,21 +24,70 @@ mod resolver;
 
 type Result<T, E = InstallerError> = core::result::Result<T, E>;
 
-pub struct Installer {
-    config: config::Config,
-    db: pkgdb::Database,
+struct Progress<'p> {
+    start: Option<Box<dyn FnMut(&str, u64) + 'p>>,
+    update: Option<Box<dyn FnMut(&str, u64) + 'p>>,
+    finish: Option<Box<dyn FnMut(&str) + 'p>>,
 }
 
-impl Installer {
+impl<'p> Progress<'p> {
+    fn start(&mut self, id: &str, len: u64) {
+        if let Some(cb) = &mut self.start {
+            (cb)(id, len);
+        }
+    }
+
+    fn update(&mut self, id: &str, delta: u64) {
+        if let Some(cb) = &mut self.update {
+            (cb)(id, delta);
+        }
+    }
+
+    fn finish(&mut self, id: &str) {
+        if let Some(cb) = &mut self.finish {
+            (cb)(id);
+        }
+    }
+}
+
+pub struct Installer<'p> {
+    config: config::Config,
+    db: pkgdb::Database,
+    progress: Progress<'p>,
+}
+
+impl<'p> Installer<'p> {
     pub fn new(config: config::Config, fs: VfsPath, rid: &str) -> Result<Installer> {
         // We're using MD5 here because it's short and fast, we're not using
         // this in a security sensitive aspect.
         let id = format!("{:x}", md5::compute(rid));
         let db = pkgdb::Database::new(fs, id)?;
 
-        Ok(Installer { config, db })
+        Ok(Installer {
+            config,
+            db,
+            progress: Progress {
+                start: None,
+                update: None,
+                finish: None,
+            },
+        })
     }
 
+    pub fn with_progress_start(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+        self.progress.start = Some(Box::new(cb))
+    }
+
+    pub fn with_progress_update(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+        self.progress.update = Some(Box::new(cb))
+    }
+
+    pub fn with_progress_finish(&mut self, cb: impl FnMut(&str) + 'p) {
+        self.progress.finish = Some(Box::new(cb))
+    }
+}
+
+impl<'p> Installer<'p> {
     pub fn install(&mut self, packages: &[PackageSpecifier]) -> Result<()> {
         transaction!(self.db, {
             // Add all of the packages being requested to the set of all requested packages.
@@ -54,6 +103,14 @@ impl Installer {
                 requested.insert(req.name.clone(), req.version.clone());
             }
 
+            self.progress.start("test", 30);
+            for _ in 0..30 {
+                std::thread::sleep(std::time::Duration::from_millis(250));
+                // info!(target: "mqpkg", "test");
+                self.progress.update("test", 1);
+            }
+            self.progress.finish("test");
+
             // Resolve all of our requirements to a full set of packages that we should install
             let _solution = self.resolve(requested)?;
         });
@@ -62,7 +119,7 @@ impl Installer {
     }
 }
 
-impl Installer {
+impl<'p> Installer<'p> {
     fn resolve(&self, requested: RequestedPackages) -> Result<SolverSolution> {
         let repository = repository::Repository::new()?.fetch(self.config.repositories())?;
         let solver = resolver::Solver::new(repository);

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -89,12 +89,16 @@ impl<'p, T> Installer<'p, T> {
 
 impl<'p, T> Installer<'p, T> {
     fn resolve(&self, requested: RequestedPackages) -> Result<SolverSolution> {
-        let repository = repository::Repository::new(self.progress.clone())?
-            .fetch(self.config.repositories())?;
-        let solver = resolver::Solver::new(repository);
-        let spinner = self.progress.spinner("Resolving dependencies");
-        let solution = solver.resolve(requested, || spinner.update(1))?;
+        let bar = self
+            .progress
+            .bar(self.config.repositories().len().try_into().unwrap());
+        let repository =
+            repository::Repository::new()?.fetch(self.config.repositories(), || bar.update(1))?;
+        bar.finish();
 
+        let spinner = self.progress.spinner("Resolving dependencies");
+        let solver = resolver::Solver::new(repository);
+        let solution = solver.resolve(requested, || spinner.update(1))?;
         spinner.finish();
 
         Ok(solution)

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -15,12 +15,12 @@ pub use crate::config::Config;
 pub use crate::errors::{InstallerError, SolverError};
 pub use crate::types::PackageSpecifier;
 
+pub(crate) mod progress;
 pub(crate) mod types;
 
 mod config;
 mod errors;
 mod pkgdb;
-mod progress;
 mod repository;
 mod resolver;
 
@@ -85,7 +85,8 @@ impl<'p, T> Installer<'p, T> {
 
 impl<'p, T> Installer<'p, T> {
     fn resolve(&self, requested: RequestedPackages) -> Result<SolverSolution> {
-        let repository = repository::Repository::new()?.fetch(self.config.repositories())?;
+        let repository = repository::Repository::new(self.progress.clone())?
+            .fetch(self.config.repositories())?;
         let solver = resolver::Solver::new(repository);
         let solution = solver.resolve(requested)?;
 

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -50,6 +50,10 @@ impl<'p, T> Installer<'p, T> {
         self.progress.with_progress_start(Box::new(cb))
     }
 
+    pub fn with_progress_spinner(&mut self, cb: impl FnMut(&'static str) -> T + 'p) {
+        self.progress.with_progress_spinner(Box::new(cb))
+    }
+
     pub fn with_progress_update(&mut self, cb: impl FnMut(&T, u64) + 'p) {
         self.progress.with_progress_update(Box::new(cb))
     }
@@ -88,7 +92,10 @@ impl<'p, T> Installer<'p, T> {
         let repository = repository::Repository::new(self.progress.clone())?
             .fetch(self.config.repositories())?;
         let solver = resolver::Solver::new(repository);
-        let solution = solver.resolve(requested)?;
+        let spinner = self.progress.spinner("Resolving dependencies");
+        let solution = solver.resolve(requested, || spinner.update(1))?;
+
+        spinner.finish();
 
         Ok(solution)
     }

--- a/mqpkg/src/lib.rs
+++ b/mqpkg/src/lib.rs
@@ -5,7 +5,6 @@
 use std::clone::Clone;
 use std::collections::HashMap;
 
-use log::info;
 use vfs::VfsPath;
 
 use crate::pkgdb::transaction;
@@ -75,22 +74,6 @@ impl<'p, T> Installer<'p, T> {
             for req in self.db.requested()?.values() {
                 requested.insert(req.name.clone(), req.version.clone());
             }
-
-            let bar = self.progress.bar(30);
-            for _ in 0..30 {
-                std::thread::sleep(std::time::Duration::from_millis(250));
-                info!(target: "mqpkg", "test");
-                bar.update(1);
-            }
-            bar.finish();
-
-            let bar = self.progress.bar(30);
-            for _ in 0..30 {
-                std::thread::sleep(std::time::Duration::from_millis(250));
-                info!(target: "mqpkg", "test");
-                bar.update(1);
-            }
-            bar.finish();
 
             // Resolve all of our requirements to a full set of packages that we should install
             let _solution = self.resolve(requested)?;

--- a/mqpkg/src/progress.rs
+++ b/mqpkg/src/progress.rs
@@ -4,38 +4,39 @@
 
 use std::sync::{Arc, Mutex};
 
-struct ProgressInternal<'p> {
-    start: Option<Box<dyn FnMut(&str, u64) + 'p>>,
-    update: Option<Box<dyn FnMut(&str, u64) + 'p>>,
-    finish: Option<Box<dyn FnMut(&str) + 'p>>,
+struct ProgressInternal<'p, T> {
+    start: Option<Box<dyn FnMut(u64) -> T + 'p>>,
+    update: Option<Box<dyn FnMut(&T, u64) + 'p>>,
+    finish: Option<Box<dyn FnMut(&T) + 'p>>,
 }
 
-impl<'p> ProgressInternal<'p> {
-    fn start(&mut self, id: &str, len: u64) {
-        if let Some(cb) = &mut self.start {
-            (cb)(id, len);
+impl<'p, T> ProgressInternal<'p, T> {
+    fn start(&mut self, len: u64) -> Option<T> {
+        match &mut self.start {
+            Some(cb) => Some((cb)(len)),
+            None => None,
         }
     }
 
-    fn update(&mut self, id: &str, delta: u64) {
+    fn update(&mut self, bar: &T, delta: u64) {
         if let Some(cb) = &mut self.update {
-            (cb)(id, delta);
+            (cb)(bar, delta);
         }
     }
 
-    fn finish(&mut self, id: &str) {
+    fn finish(&mut self, bar: &T) {
         if let Some(cb) = &mut self.finish {
-            (cb)(id);
+            (cb)(bar);
         }
     }
 }
 
-pub(crate) struct Progress<'p> {
-    internal: Arc<Mutex<ProgressInternal<'p>>>,
+pub(crate) struct Progress<'p, T> {
+    internal: Arc<Mutex<ProgressInternal<'p, T>>>,
 }
 
-impl<'p> Progress<'p> {
-    pub(crate) fn new() -> Progress<'p> {
+impl<'p, T> Progress<'p, T> {
+    pub(crate) fn new() -> Progress<'p, T> {
         Progress {
             internal: Arc::new(Mutex::new(ProgressInternal {
                 start: None,
@@ -45,58 +46,57 @@ impl<'p> Progress<'p> {
         }
     }
 
-    pub(crate) fn with_progress_start(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+    pub(crate) fn with_progress_start(&mut self, cb: impl FnMut(u64) -> T + 'p) {
         let mut internal = self.internal.lock().unwrap();
         internal.start = Some(Box::new(cb))
     }
 
-    pub(crate) fn with_progress_update(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+    pub(crate) fn with_progress_update(&mut self, cb: impl FnMut(&T, u64) + 'p) {
         let mut internal = self.internal.lock().unwrap();
         internal.update = Some(Box::new(cb))
     }
 
-    pub(crate) fn with_progress_finish(&mut self, cb: impl FnMut(&str) + 'p) {
+    pub(crate) fn with_progress_finish(&mut self, cb: impl FnMut(&T) + 'p) {
         let mut internal = self.internal.lock().unwrap();
         internal.finish = Some(Box::new(cb))
     }
 }
 
-impl<'p> Progress<'p> {
-    pub(crate) fn bar(&self, name: &str, len: u64) -> ProgressBar<'p> {
-        ProgressBar::new(self.internal.clone(), name, len)
+impl<'p, T> Progress<'p, T> {
+    pub(crate) fn bar(&self, len: u64) -> ProgressBar<'p, T> {
+        ProgressBar::new(self.internal.clone(), len)
     }
 }
 
-pub(crate) struct ProgressBar<'p> {
-    name: String,
-    internal: Arc<Mutex<ProgressInternal<'p>>>,
+pub(crate) struct ProgressBar<'p, T> {
+    bar: Option<Box<T>>,
+    internal: Arc<Mutex<ProgressInternal<'p, T>>>,
 }
 
-impl<'p> ProgressBar<'p> {
-    fn new<S: Into<String>>(
-        internal: Arc<Mutex<ProgressInternal<'p>>>,
-        name: S,
-        len: u64,
-    ) -> ProgressBar<'p> {
-        let name = name.into();
-        let bar = ProgressBar { name, internal };
+impl<'p, T> ProgressBar<'p, T> {
+    fn new(internal: Arc<Mutex<ProgressInternal<'p, T>>>, len: u64) -> ProgressBar<'p, T> {
+        let mut lock = internal.lock().unwrap();
+        let bar = match lock.start(len) {
+            Some(b) => Some(Box::new(b)),
+            None => None,
+        };
 
-        bar.start(len);
-        bar
-    }
+        drop(lock);
 
-    fn start(&self, len: u64) {
-        let mut internal = self.internal.lock().unwrap();
-        internal.start(self.name.as_str(), len);
+        ProgressBar { internal, bar }
     }
 
     pub(crate) fn update(&self, delta: u64) {
-        let mut internal = self.internal.lock().unwrap();
-        internal.update(self.name.as_str(), delta);
+        if let Some(bar) = &self.bar {
+            let mut internal = self.internal.lock().unwrap();
+            internal.update(&**bar, delta);
+        }
     }
 
     pub(crate) fn finish(&self) {
-        let mut internal = self.internal.lock().unwrap();
-        internal.finish(self.name.as_str());
+        if let Some(bar) = &self.bar {
+            let mut internal = self.internal.lock().unwrap();
+            internal.finish(&**bar);
+        }
     }
 }

--- a/mqpkg/src/progress.rs
+++ b/mqpkg/src/progress.rs
@@ -2,12 +2,19 @@
 // 2.0, and the BSD License. See the LICENSE file in the root of this repository
 // for complete details.
 
+use std::fmt;
 use std::sync::{Arc, Mutex};
 
 struct ProgressInternal<'p, T> {
     start: Option<Box<dyn FnMut(u64) -> T + 'p>>,
     update: Option<Box<dyn FnMut(&T, u64) + 'p>>,
     finish: Option<Box<dyn FnMut(&T) + 'p>>,
+}
+
+impl<'p, T> fmt::Debug for ProgressInternal<'p, T> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ProgressInternal").finish()
+    }
 }
 
 impl<'p, T> ProgressInternal<'p, T> {
@@ -28,8 +35,17 @@ impl<'p, T> ProgressInternal<'p, T> {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct Progress<'p, T> {
     internal: Arc<Mutex<ProgressInternal<'p, T>>>,
+}
+
+impl<'p, T> Clone for Progress<'p, T> {
+    fn clone(&self) -> Self {
+        Progress {
+            internal: self.internal.clone(),
+        }
+    }
 }
 
 impl<'p, T> Progress<'p, T> {

--- a/mqpkg/src/progress.rs
+++ b/mqpkg/src/progress.rs
@@ -1,0 +1,102 @@
+// This file is dual licensed under the terms of the Apache License, Version
+// 2.0, and the BSD License. See the LICENSE file in the root of this repository
+// for complete details.
+
+use std::sync::{Arc, Mutex};
+
+struct ProgressInternal<'p> {
+    start: Option<Box<dyn FnMut(&str, u64) + 'p>>,
+    update: Option<Box<dyn FnMut(&str, u64) + 'p>>,
+    finish: Option<Box<dyn FnMut(&str) + 'p>>,
+}
+
+impl<'p> ProgressInternal<'p> {
+    fn start(&mut self, id: &str, len: u64) {
+        if let Some(cb) = &mut self.start {
+            (cb)(id, len);
+        }
+    }
+
+    fn update(&mut self, id: &str, delta: u64) {
+        if let Some(cb) = &mut self.update {
+            (cb)(id, delta);
+        }
+    }
+
+    fn finish(&mut self, id: &str) {
+        if let Some(cb) = &mut self.finish {
+            (cb)(id);
+        }
+    }
+}
+
+pub(crate) struct Progress<'p> {
+    internal: Arc<Mutex<ProgressInternal<'p>>>,
+}
+
+impl<'p> Progress<'p> {
+    pub(crate) fn new() -> Progress<'p> {
+        Progress {
+            internal: Arc::new(Mutex::new(ProgressInternal {
+                start: None,
+                update: None,
+                finish: None,
+            })),
+        }
+    }
+
+    pub(crate) fn with_progress_start(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.start = Some(Box::new(cb))
+    }
+
+    pub(crate) fn with_progress_update(&mut self, cb: impl FnMut(&str, u64) + 'p) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.update = Some(Box::new(cb))
+    }
+
+    pub(crate) fn with_progress_finish(&mut self, cb: impl FnMut(&str) + 'p) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.finish = Some(Box::new(cb))
+    }
+}
+
+impl<'p> Progress<'p> {
+    pub(crate) fn bar(&self, name: &str, len: u64) -> ProgressBar<'p> {
+        ProgressBar::new(self.internal.clone(), name, len)
+    }
+}
+
+pub(crate) struct ProgressBar<'p> {
+    name: String,
+    internal: Arc<Mutex<ProgressInternal<'p>>>,
+}
+
+impl<'p> ProgressBar<'p> {
+    fn new<S: Into<String>>(
+        internal: Arc<Mutex<ProgressInternal<'p>>>,
+        name: S,
+        len: u64,
+    ) -> ProgressBar<'p> {
+        let name = name.into();
+        let bar = ProgressBar { name, internal };
+
+        bar.start(len);
+        bar
+    }
+
+    fn start(&self, len: u64) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.start(self.name.as_str(), len);
+    }
+
+    pub(crate) fn update(&self, delta: u64) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.update(self.name.as_str(), delta);
+    }
+
+    pub(crate) fn finish(&self) {
+        let mut internal = self.internal.lock().unwrap();
+        internal.finish(self.name.as_str());
+    }
+}

--- a/mqpkg/src/progress.rs
+++ b/mqpkg/src/progress.rs
@@ -12,10 +12,7 @@ struct ProgressInternal<'p, T> {
 
 impl<'p, T> ProgressInternal<'p, T> {
     fn start(&mut self, len: u64) -> Option<T> {
-        match &mut self.start {
-            Some(cb) => Some((cb)(len)),
-            None => None,
-        }
+        self.start.as_mut().map(|cb| (cb)(len))
     }
 
     fn update(&mut self, bar: &T, delta: u64) {
@@ -76,10 +73,7 @@ pub(crate) struct ProgressBar<'p, T> {
 impl<'p, T> ProgressBar<'p, T> {
     fn new(internal: Arc<Mutex<ProgressInternal<'p, T>>>, len: u64) -> ProgressBar<'p, T> {
         let mut lock = internal.lock().unwrap();
-        let bar = match lock.start(len) {
-            Some(b) => Some(Box::new(b)),
-            None => None,
-        };
+        let bar = lock.start(len).map(Box::new);
 
         drop(lock);
 

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -7,6 +7,7 @@ use std::fs::File;
 use std::io::BufReader;
 
 use indexmap::IndexMap;
+use log::info;
 use reqwest::blocking::Client as HTTPClient;
 use semver::VersionReq;
 use serde::Deserialize;
@@ -62,6 +63,7 @@ impl<'p, T> Repository<'p, T> {
     }
 
     pub(crate) fn fetch(mut self, repos: &[config::Repository]) -> Result<Repository<'p, T>> {
+        info!(target: "mqpkg::repository::fetch", "Fetching package metadata");
         let bar = self.progress.bar(repos.len().try_into().unwrap());
         for repo in repos.iter() {
             let data: RepoData = match repo.url.scheme() {

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -18,6 +18,8 @@ use crate::errors::RepositoryError;
 use crate::progress::Progress;
 use crate::types::{PackageName, Version};
 
+const LOGNAME: &str = "mqpkg::repository";
+
 type Result<T, E = RepositoryError> = core::result::Result<T, E>;
 
 #[derive(Deserialize, Debug)]
@@ -63,7 +65,7 @@ impl<'p, T> Repository<'p, T> {
     }
 
     pub(crate) fn fetch(mut self, repos: &[config::Repository]) -> Result<Repository<'p, T>> {
-        info!(target: "mqpkg::repository::fetch", "Fetching package metadata");
+        info!(target: LOGNAME, "fetching package metadata");
         let bar = self.progress.bar(repos.len().try_into().unwrap());
         for repo in repos.iter() {
             let data: RepoData = match repo.url.scheme() {

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -90,12 +90,12 @@ impl std::error::Error for HumanizedNoSolutionError {
     }
 }
 
-pub(crate) struct Solver {
-    repository: Repository,
+pub(crate) struct Solver<'p, T> {
+    repository: Repository<'p, T>,
 }
 
-impl Solver {
-    pub(crate) fn new(repository: Repository) -> Solver {
+impl<'p, T> Solver<'p, T> {
+    pub(crate) fn new(repository: Repository<'p, T>) -> Solver<'p, T> {
         Solver { repository }
     }
 
@@ -119,17 +119,17 @@ impl Solver {
 // to persist between runs will only live on the InternalSolver. Anything we want
 // to persist long term, lives on the Solver and gets passed into InternalSolver
 // as a reference.
-struct InternalSolver<'r> {
-    repository: &'r Repository,
+struct InternalSolver<'r, 'p, T> {
+    repository: &'r Repository<'p, T>,
     root: PackageName,
     requested: RequestedPackages,
 }
 
-impl<'r> DependencyProvider<PackageName, Version> for InternalSolver<'r> {
-    fn choose_package_version<T: Borrow<PackageName>, U: Borrow<Range<Version>>>(
+impl<'r, 'p, T> DependencyProvider<PackageName, Version> for InternalSolver<'r, 'p, T> {
+    fn choose_package_version<P: Borrow<PackageName>, U: Borrow<Range<Version>>>(
         &self,
-        potential_packages: impl Iterator<Item = (T, U)>,
-    ) -> Result<(T, Option<Version>), Box<dyn std::error::Error>> {
+        potential_packages: impl Iterator<Item = (P, U)>,
+    ) -> Result<(P, Option<Version>), Box<dyn std::error::Error>> {
         Ok(choose_package_with_fewest_versions(
             |package| {
                 if package == &self.root {

--- a/mqpkg/src/resolver.rs
+++ b/mqpkg/src/resolver.rs
@@ -93,12 +93,12 @@ impl std::error::Error for HumanizedNoSolutionError {
     }
 }
 
-pub(crate) struct Solver<'p, T> {
-    repository: Repository<'p, T>,
+pub(crate) struct Solver {
+    repository: Repository,
 }
 
-impl<'p, T> Solver<'p, T> {
-    pub(crate) fn new(repository: Repository<'p, T>) -> Solver<'p, T> {
+impl Solver {
+    pub(crate) fn new(repository: Repository) -> Solver {
         Solver { repository }
     }
 
@@ -129,14 +129,14 @@ impl<'p, T> Solver<'p, T> {
 // to persist between runs will only live on the InternalSolver. Anything we want
 // to persist long term, lives on the Solver and gets passed into InternalSolver
 // as a reference.
-struct InternalSolver<'r, 'c, 'p, T> {
-    repository: &'r Repository<'p, T>,
+struct InternalSolver<'r, 'c> {
+    repository: &'r Repository,
     root: PackageName,
     requested: RequestedPackages,
     callback: Box<dyn Fn() + 'c>,
 }
 
-impl<'r, 'c, 'p, T> DependencyProvider<PackageName, Version> for InternalSolver<'r, 'c, 'p, T> {
+impl<'r, 'c> DependencyProvider<PackageName, Version> for InternalSolver<'r, 'c> {
     fn should_cancel(&self) -> Result<(), Box<dyn std::error::Error>> {
         (self.callback)();
         Ok(())


### PR DESCRIPTION
This provides the facilities for user oriented output (console messages), logging (for debugging or extra information), and progress bars (for.. progress monitoring).

They're all integrated so that you can use any mix of them and output is consistent, as well as integrating with the typical ``-q`` and ``-v`` flags to decrease/increase the amount of output.

The actual use of ouputting or constructing the progress bars and loggers is offloaded to the binary crate so that the library itself is agnostic towards it, and by default they're simply no-ops. The binary crate sends all console output to stdout, and progress/logging to stderr.

Also uses these facilities to start providing logging and user output.

Examples:

```
$ mqpkg install --target demo/mq example
[1/2] 📄  Fetched package metadata
[2/2] 🔍  Resolved dependencies
```

```
$ mqpkg install --target demo/mq example -vvvv
 INFO  mqpkg > using root directory: 'C:\Users\Donald\Projects\mqpkg\demo\mq'
 INFO  mqpkg::config > loading config from "/mqpkg.yml"
 TRACE mqpkg::pkgdb  > begin transaction
 TRACE mqpkg::pkgdb  > loading state from "/pkgdb/state.yml"
 TRACE mqpkg::pkgdb  > adding example(*) to requested packages
 TRACE reqwest::blocking::wait > (ThreadId(1)) park without timeout
 TRACE reqwest::blocking::client > (ThreadId(2)) start runtime::block_on
 INFO  mqpkg::repository         > fetching package metadata
[1/2] 📄  Fetched package metadata
 INFO  mqpkg::resolver           > resolving requested packages
 TRACE mqpkg::resolver           > found versions for :requested:: [1.0.0]
 TRACE mqpkg::resolver           > found versions for :requested:: [1.0.0]
 TRACE mqpkg::resolver           > selected :requested: (1.0.0) as next candidate
 TRACE mqpkg::resolver           > found dependencies for :requested: (1.0.0): [example(*)]
 TRACE mqpkg::resolver           > found versions for example: [1.0.5, 1.0.2, 1.0.0]
 TRACE mqpkg::resolver           > found versions for example: [1.0.5, 1.0.2, 1.0.0]
 TRACE mqpkg::resolver           > selected example (1.0.5) as next candidate
 TRACE mqpkg::resolver           > found dependencies for example (1.0.5): [anotherdep(=0.4.0), mydep(*)]
 TRACE mqpkg::resolver           > found versions for mydep: [0.5.0]
 TRACE mqpkg::resolver           > found versions for anotherdep: [0.5.0, 0.4.0]
 TRACE mqpkg::resolver           > found versions for mydep: [0.5.0]
 TRACE mqpkg::resolver           > selected mydep (0.5.0) as next candidate
 TRACE mqpkg::resolver           > found dependencies for mydep (0.5.0): [anotherdep(=0.4.0)]
 TRACE mqpkg::resolver           > found versions for anotherdep: [0.5.0, 0.4.0]
 TRACE mqpkg::resolver           > found versions for anotherdep: [0.5.0, 0.4.0]
 TRACE mqpkg::resolver           > selected anotherdep (0.4.0) as next candidate
 TRACE mqpkg::resolver           > found dependencies for anotherdep (0.4.0): []
[2/2] 🔍  Resolved dependencies
 TRACE reqwest::blocking::client > closing runtime thread (ThreadId(2))
 TRACE reqwest::blocking::client > signaled close for runtime thread (ThreadId(2))
 TRACE reqwest::blocking::client > (ThreadId(2)) Receiver is shutdown
 TRACE reqwest::blocking::client > (ThreadId(2)) end runtime::block_on
 TRACE reqwest::blocking::client > (ThreadId(2)) finished
 TRACE reqwest::blocking::client > closed runtime thread (ThreadId(2))
 TRACE mqpkg::pkgdb              > commit transaction
 TRACE mqpkg::pkgdb              > saving state to "/pkgdb/state.yml"
```

