### PR TITLE
Have Repository return Candidates

### DIFF
--- a/mqpkg/src/config.rs
+++ b/mqpkg/src/config.rs
@@ -19,7 +19,7 @@ const CONFIG_FILENAME: &str = "mqpkg.yml";
 
 type Result<T, E = ConfigError> = core::result::Result<T, E>;
 
-#[derive(Deserialize, Debug, Clone)]
+#[derive(Deserialize, Debug, Clone, Eq, PartialEq, Hash)]
 pub(crate) struct Repository {
     pub(crate) name: String,
     pub(crate) url: Url,

--- a/mqpkg/src/errors.rs
+++ b/mqpkg/src/errors.rs
@@ -4,8 +4,8 @@
 
 use thiserror::Error;
 
-use crate::resolver::{Candidate, DerivedResult};
-use crate::types::PackageName;
+use crate::resolver::DerivedResult;
+use crate::types::{Candidate, PackageName};
 
 #[derive(Error, Debug)]
 pub enum InstallerError {

--- a/mqpkg/src/errors.rs
+++ b/mqpkg/src/errors.rs
@@ -104,7 +104,7 @@ pub enum SolverError {
         /// Package whose dependencies we want.
         package: PackageName,
         /// Version of the package for which we want the dependencies.
-        version: Candidate,
+        version: Box<Candidate>,
         /// The dependent package that requires us to pick from the empty set.
         dependent: PackageName,
     },
@@ -114,7 +114,7 @@ pub enum SolverError {
         /// Package whose dependencies we want.
         package: PackageName,
         /// Version of the package for which we want the dependencies.
-        version: Candidate,
+        version: Box<Candidate>,
     },
 
     // PubGrubError has a Failure error, and I'm not sure where it would actually

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -47,13 +47,13 @@ struct RepoData {
 #[derive(Debug)]
 pub(crate) struct Repository {
     client: HTTPClient,
-    data: IndexMap<String, RepoData>,
+    data: IndexMap<config::Repository, RepoData>,
 }
 
 impl Repository {
     pub(crate) fn new() -> Result<Repository> {
         let client = HTTPClient::builder().gzip(true).build()?;
-        let data = IndexMap::<String, RepoData>::new();
+        let data = IndexMap::<config::Repository, RepoData>::new();
 
         Ok(Repository { client, data })
     }
@@ -79,7 +79,7 @@ impl Repository {
                     .error_for_status()?
                     .json()?,
             };
-            self.data.insert(repo.name.clone(), data);
+            self.data.insert(repo.clone(), data);
             (callback)();
         }
 
@@ -93,10 +93,10 @@ impl Repository {
         // that our Vec is sorted by the order our repositories were defined in, however
         // the list of versions within that is not sorted, so we'll need to resort
         // the full list later.
-        for data in self.data.values() {
+        for (repo, data) in self.data.iter() {
             if let Some(packages) = data.packages.get(package) {
                 for version in packages.keys() {
-                    candidates.push(Candidate::new(version.clone()));
+                    candidates.push(Candidate::new(version.clone()).with_repository(repo.clone()));
                 }
             }
         }

--- a/mqpkg/src/repository.rs
+++ b/mqpkg/src/repository.rs
@@ -95,8 +95,11 @@ impl Repository {
         // the full list later.
         for (repo, data) in self.data.iter() {
             if let Some(packages) = data.packages.get(package) {
-                for version in packages.keys() {
-                    candidates.push(Candidate::new(version.clone()).with_repository(repo.clone()));
+                for (version, release) in packages.iter() {
+                    candidates.push(
+                        Candidate::new(version.clone(), release.dependencies.clone())
+                            .with_repository(repo.clone()),
+                    );
                 }
             }
         }
@@ -107,25 +110,5 @@ impl Repository {
         // this will put Version -> Repository.
         candidates.sort_by(|l, r| l.cmp(r).reverse());
         candidates
-    }
-
-    pub(crate) fn dependencies(
-        &self,
-        package: &PackageName,
-        version: &Version,
-    ) -> HashMap<PackageName, VersionReq> {
-        let mut deps = HashMap::new();
-
-        for data in self.data.values() {
-            if let Some(packages) = data.packages.get(package) {
-                if let Some(release) = packages.get(version) {
-                    for (key, value) in release.dependencies.iter() {
-                        deps.insert(key.clone(), value.clone());
-                    }
-                }
-            }
-        }
-
-        deps
     }
 }

--- a/mqpkg/src/resolver/candidates.rs
+++ b/mqpkg/src/resolver/candidates.rs
@@ -7,21 +7,21 @@ use std::fmt;
 use pubgrub::range::Range;
 use pubgrub::version::Version as PVersion;
 use pubgrub::version_set::VersionSet;
-use semver::{Prerelease, Version, VersionReq};
+use semver::{Prerelease, VersionReq};
 
 use crate::types::Candidate;
 
 impl PVersion for Candidate {
     fn lowest() -> Candidate {
-        Candidate::new(Version::new(0, 0, 0))
+        Candidate::from_parts(0, 0, 0)
     }
 
     fn bump(&self) -> Candidate {
-        Candidate::new(Version::new(
+        Candidate::from_parts(
             self.version().major,
             self.version().minor,
             self.version().patch + 1,
-        ))
+        )
     }
 }
 
@@ -38,7 +38,7 @@ impl fmt::Display for CandidateSet {
 }
 
 impl CandidateSet {
-    pub(super) fn req(req: VersionReq) -> CandidateSet {
+    pub(super) fn req(req: &VersionReq) -> CandidateSet {
         // By default, we allow *any* normal version to be accepted,
         // then we futher constrain those down.
         let mut range = Range::full();

--- a/mqpkg/src/resolver/mod.rs
+++ b/mqpkg/src/resolver/mod.rs
@@ -41,12 +41,13 @@ impl SolverError {
                 dependent,
             } => SolverError::DependencyOnTheEmptySet {
                 package,
-                version,
+                version: Box::new(version),
                 dependent,
             },
-            PubGrubError::SelfDependency { package, version } => {
-                SolverError::SelfDependency { package, version }
-            }
+            PubGrubError::SelfDependency { package, version } => SolverError::SelfDependency {
+                package,
+                version: Box::new(version),
+            },
             PubGrubError::Failure(s) => SolverError::Failure(s),
             PubGrubError::ErrorRetrievingDependencies { .. } => SolverError::Impossible,
             PubGrubError::ErrorChoosingPackageVersion(_) => SolverError::Impossible,

--- a/mqpkg/src/types.rs
+++ b/mqpkg/src/types.rs
@@ -13,6 +13,7 @@ use std::str::FromStr;
 use semver::{Prerelease, Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
+use crate::config::Repository;
 use crate::errors::{PackageNameError, PackageSpecifierError};
 
 #[derive(Serialize, Deserialize, Clone, Eq, Debug, Hash, PartialEq)]
@@ -88,11 +89,16 @@ pub(crate) type RequestedPackages = HashMap<PackageName, VersionReq>;
 pub struct Candidate {
     is_root: bool,
     version: Version,
+    repository: Option<Repository>,
 }
 
 impl Candidate {
     pub(crate) fn version(&self) -> &Version {
         &self.version
+    }
+
+    pub(crate) fn repository(&self) -> Option<&Repository> {
+        self.repository.as_ref()
     }
 }
 
@@ -108,6 +114,7 @@ impl Candidate {
         Candidate {
             is_root: false,
             version,
+            repository: None,
         }
     }
 
@@ -115,6 +122,7 @@ impl Candidate {
         Candidate {
             is_root: true,
             version: Version::new(0, 0, 0),
+            repository: None,
         }
     }
 
@@ -122,6 +130,7 @@ impl Candidate {
         Candidate {
             is_root: false,
             version: Version::new(major, minor, patch),
+            repository: None,
         }
     }
 
@@ -132,7 +141,15 @@ impl Candidate {
         Candidate {
             is_root: false,
             version,
+            repository: None,
         }
+    }
+
+    pub(crate) fn with_repository(&self, repo: Repository) -> Candidate {
+        let mut c = self.clone();
+
+        c.repository = Some(repo);
+        c
     }
 }
 


### PR DESCRIPTION
Previously ``Repsoitory`` had two methods, ``versions(PackageName)`` and ``dependencies(PackageName, Version)`` which the resolver would use to get all of the versions for a given package, then all of the dependencies for a version of that package.

This breaks in the presence of multiple repositories that do not have a globally consistent definition of what dependencies a version of a package should have. This largely boils down to the assumption that (package, version) is enough to uniquely identify an artifact, when in reality it needs to be (package, version, repository).

In order to enable this, ``Repository`` now has a singular method, ``candidates(PackageName)``, which the resolver can use to get a list of Candidates for a particular package. This will return candidates that have even the same version number from different repositories, because ultimately a candidate is identified by (package, version, repository).

